### PR TITLE
Expand the Datadog logs payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,7 +293,7 @@ dependencies = [
 
 [[package]]
 name = "file_gen"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "argh",
  "byte-unit",
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "http_gen"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "argh",
  "byte-unit",
@@ -604,7 +604,7 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "lading_common"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "arbitrary",
  "bytecount",
@@ -1287,7 +1287,7 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "udp_blackhole"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "argh",
  "metrics",

--- a/lading_common/Cargo.toml
+++ b/lading_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading_common"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
 license = "MIT"

--- a/lading_common/src/payload/datadog_logs.rs
+++ b/lading_common/src/payload/datadog_logs.rs
@@ -5,21 +5,42 @@ use rand::Rng;
 use std::io::Write;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
+// https://github.com/DataDog/datadog-agent/blob/a33248c2bc125920a9577af1e16f12298875a4ad/pkg/logs/processor/json.go#L23-L49
 struct Member {
     /// The message is a short ascii string, without newlines for now
     pub message: String,
+    /// The message status
+    pub status: String,
     /// The timestamp is a simple integer value since epoch, presumably
     pub timestamp: u32,
+    /// The hostname that sent the logs
+    pub hostname: String,
+    /// The service that sent the logs
+    pub service: String,
+    /// The ultimate source of the logs
+    pub source: String,
+    /// Comma-separate list of tags
+    pub tags: String,
 }
 
 impl<'a> arbitrary::Arbitrary<'a> for Member {
     fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
         let ascii_str = u.arbitrary::<AsciiStr>()?;
+        let status = u.arbitrary::<AsciiStr>()?;
         let timestamp = u.arbitrary::<u32>()?;
+        let hostname = u.arbitrary::<AsciiStr>()?;
+        let service = u.arbitrary::<AsciiStr>()?;
+        let source = u.arbitrary::<AsciiStr>()?;
+        let tags = u.arbitrary::<AsciiStr>()?;
 
         Ok(Member {
             message: ascii_str.as_str().to_string(),
+            status: status.as_str().to_string(),
             timestamp,
+            hostname: hostname.as_str().to_string(),
+            service: service.as_str().to_string(),
+            source: source.as_str().to_string(),
+            tags: tags.as_str().to_string(),
         })
     }
 

--- a/udp_blackhole/Cargo.toml
+++ b/udp_blackhole/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "udp_blackhole"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
After discussion in https://github.com/timberio/vector/pull/8297 I've realized
that the logs payload here was too meager, not reflective of the actual datadog
logs agent. This commit addresses that.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>