### PR TITLE
Introduce `http_blackhole`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,6 +88,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "blackhole"
+version = "0.4.2"
+dependencies = [
+ "argh",
+ "hyper",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "tokio",
+]
+
+[[package]]
 name = "byte-unit"
 version = "4.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1284,15 +1295,6 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "udp_blackhole"
-version = "0.4.1"
-dependencies = [
- "argh",
- "metrics",
- "tokio",
-]
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = [
   "lading_common",
   "file_gen",
-  "udp_blackhole",
+  "blackhole",
   "http_gen",
 ]
 

--- a/blackhole/Cargo.toml
+++ b/blackhole/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "udp_blackhole"
+name = "blackhole"
 version = "0.4.2"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
@@ -10,18 +10,26 @@ categories = ["command-line-utilities", "development-tools::profiling"]
 description = "A UDP blackhole program with some instrumentation"
 
 [dependencies]
+metrics = { version = "0.16", default-features = false, features = ["std"] }
+metrics-exporter-prometheus = { version = "0.5", default-features = false, features = ["tokio-exporter"] }
 
 [dependencies.argh]
 version = "0.1"
 default-features = false
 features = []
 
-[dependencies.metrics]
-version = "0.16"
+[dependencies.hyper]
+version = "0.14"
 default-features = false
-features = ["std"]
+features = []
 
 [dependencies.tokio]
 version = "1.8"
 default-features = false
 features = ["rt", "rt-multi-thread", "macros", "fs", "io-util"]
+
+[[bin]]
+name = "udp_blackhole"
+
+[[bin]]
+name = "http_blackhole"

--- a/blackhole/README.md
+++ b/blackhole/README.md
@@ -1,0 +1,5 @@
+# `blackhole` - a collection of blackhole programs
+
+The programs in this sub-project are blackholes. For instance, `udp_blackhole`
+listens on a certain local UDP port, receives packets, makes a note about that
+receipt and then drops everything.

--- a/blackhole/src/bin/http_blackhole.rs
+++ b/blackhole/src/bin/http_blackhole.rs
@@ -1,0 +1,80 @@
+use argh::FromArgs;
+use hyper::header;
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Request, Response, Server, StatusCode};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use std::net::SocketAddr;
+use tokio::runtime::Builder;
+
+#[derive(FromArgs)]
+/// `http_blackhole` options
+struct Opts {
+    /// number of worker threads to use in this program
+    #[argh(option)]
+    pub worker_threads: u16,
+    /// address -- IP plus port -- to bind to
+    #[argh(option)]
+    pub binding_addr: SocketAddr,
+    /// address -- IP plus port -- for prometheus exporting to bind to
+    #[argh(option)]
+    pub prometheus_addr: SocketAddr,
+}
+
+struct HttpServer {
+    prometheus_addr: SocketAddr,
+    httpd_addr: SocketAddr,
+}
+
+async fn srv(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    match (req.method(), req.uri().path()) {
+        _ => {
+            metrics::counter!("requests_received", 1);
+            if let Some(content_length) = req.headers().get(header::CONTENT_LENGTH) {
+                let cl = content_length.to_str().unwrap();
+                let content_length = cl.parse::<u64>().unwrap();
+
+                metrics::counter!("bytes_received", content_length);
+            }
+            let mut okay = Response::default();
+            *okay.status_mut() = StatusCode::OK;
+            okay.headers_mut().insert(
+                header::CONTENT_TYPE,
+                header::HeaderValue::from_static("application/text"),
+            );
+            //            *okay.body_mut() = req.into_body();
+            Ok(okay)
+        }
+    }
+}
+
+impl HttpServer {
+    fn new(httpd_addr: SocketAddr, prometheus_addr: SocketAddr) -> Self {
+        Self {
+            httpd_addr,
+            prometheus_addr,
+        }
+    }
+
+    async fn run(self) -> Result<(), hyper::Error> {
+        let _: () = PrometheusBuilder::new()
+            .listen_address(self.prometheus_addr)
+            .install()
+            .unwrap();
+
+        let service = make_service_fn(|_| async { Ok::<_, hyper::Error>(service_fn(srv)) });
+        let server = Server::bind(&self.httpd_addr).serve(service);
+        server.await?;
+        Ok(())
+    }
+}
+
+fn main() {
+    let ops: Opts = argh::from_env();
+    let httpd = HttpServer::new(ops.binding_addr, ops.prometheus_addr);
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(ops.worker_threads as usize)
+        .enable_io()
+        .build()
+        .unwrap();
+    runtime.block_on(httpd.run()).unwrap();
+}

--- a/blackhole/src/bin/udp_blackhole.rs
+++ b/blackhole/src/bin/udp_blackhole.rs
@@ -1,6 +1,7 @@
 use argh::FromArgs;
 use metrics::counter;
 use std::io;
+use std::net::SocketAddr;
 use tokio::net::UdpSocket;
 use tokio::runtime::Builder;
 
@@ -12,15 +13,15 @@ struct Opts {
     pub worker_threads: u16,
     /// address -- IP plus port -- to bind to
     #[argh(option)]
-    pub binding_addr: String,
+    pub binding_addr: SocketAddr,
 }
 
 struct Server {
-    addr: String,
+    addr: SocketAddr,
 }
 
 impl Server {
-    fn new(addr: String) -> Self {
+    fn new(addr: SocketAddr) -> Self {
         Self { addr }
     }
 

--- a/udp_blackhole/README.md
+++ b/udp_blackhole/README.md
@@ -1,4 +1,0 @@
-# `udp_blackhole` - a lightly instrumented UDP blackhole
-
-This program listens on a certain local UDP port, receives packets, makes a note
-about that receipt and then drops everything.


### PR DESCRIPTION
This commit introduces a new program, `http_blackhole`. It is what it sounds
like, a spot for HTTP traffic to sink into. It only ever responds 200 OK to all
traffic with a blank body when that's relevant. I have moved all the blackhole
programs into a single crate and have a notion we might do the same with
generation.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>