### PR TITLE
Introduce a new generator: kafka

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,9 +21,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.15"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
 ]
@@ -73,6 +73,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d20fdac7156779a1a30d970e838195558b4810dd06aa69e7c7461bdc518edf9b"
 dependencies = [
  "crossbeam",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -152,7 +163,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -173,8 +184,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-epoch 0.9.3",
- "crossbeam-utils 0.8.3",
+ "crossbeam-epoch 0.9.5",
+ "crossbeam-utils 0.8.5",
 ]
 
 [[package]]
@@ -194,14 +205,14 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.3"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
+checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
  "cfg-if 1.0.0",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.5",
  "lazy_static",
- "memoffset 0.6.1",
+ "memoffset 0.6.4",
  "scopeguard",
 ]
 
@@ -229,20 +240,19 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
+checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "autocfg",
  "cfg-if 1.0.0",
  "lazy_static",
 ]
 
 [[package]]
 name = "ctor"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8f45d9ad417bcef4817d614a501ab55cdd96a6fdb24f49aab89a54acfd66b19"
+checksum = "5e98e2ad1a782e33928b96fc3948e7c355e5af34ba4de7670fe8bac2a3b2006d"
 dependencies = [
  "quote",
  "syn",
@@ -256,6 +266,17 @@ checksum = "e77a43b28d0668df09411cb0bc9a8c2adc40f9a048afe863e05fd43251e8e39c"
 dependencies = [
  "cfg-if 1.0.0",
  "num_cpus",
+]
+
+[[package]]
+name = "derivative"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc3dd5e9e9c0b295d6e1e4d811fb6f157d5ffd784b8d202fc62eac8035a770b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -280,6 +301,19 @@ name = "endian-type"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "env_logger"
@@ -399,9 +433,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
@@ -455,12 +489,6 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
-
-[[package]]
-name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
@@ -470,18 +498,18 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
+checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.18"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
@@ -499,12 +527,13 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+checksum = "60daa14be0e0786db0f03a9e57cb404c9d756eed2b6c62b9ea98ec5743ec75a9"
 dependencies = [
  "bytes",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -530,6 +559,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6456b8a6c8f33fee7d958fcd1b60d55b11940a79e63ae87013e6d22e26034440"
 
 [[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,7 +584,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.0",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -555,28 +593,28 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+checksum = "bc633605454125dec4b66843673f01c7df2b89479b32e0ed634e43a91cff62a5"
 dependencies = [
  "autocfg",
- "hashbrown 0.9.1",
+ "hashbrown 0.11.2",
 ]
 
 [[package]]
 name = "instant"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
+checksum = "bee0328b1209d157ef001c94dd85b4f8f64139adb0eac2659f4b08382b2f474d"
 dependencies = [
  "cfg-if 1.0.0",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47be2f14c678be2fdcab04ab1171db51b2762ce6f0a8ee87c8dd4a04ed216135"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
 
 [[package]]
 name = "itoa"
@@ -623,8 +661,10 @@ dependencies = [
  "lading_common",
  "metrics 0.17.0",
  "metrics-exporter-prometheus",
+ "pretty_env_logger",
  "rand",
  "rayon",
+ "rdkafka",
  "serde",
  "tokio",
  "toml",
@@ -638,15 +678,15 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.87"
+version = "0.2.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "265d751d31d6780a3f956bb5b8022feba2d94eeee5a84ba64f4212eedca42213"
+checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "0382880606dff6d15c9476c416d18690b72742aa7b605bb6dd6ec9030fbf07eb"
 dependencies = [
  "scopeguard",
 ]
@@ -677,9 +717,9 @@ checksum = "60302e4db3a61da70c0cb7991976248362f30319e88850c487b9b95bbf059e00"
 
 [[package]]
 name = "memchr"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+checksum = "b16bd47d9e329435e309c58469fe0791c2d0d1ba96ec0954152a5ae2b04387dc"
 
 [[package]]
 name = "memoffset"
@@ -692,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "59accc507f1338036a0477ef61afdae33cde60840f4dfe481319ce3ad116ddf9"
 dependencies = [
  "autocfg",
 ]
@@ -760,8 +800,8 @@ dependencies = [
  "ahash 0.7.4",
  "aho-corasick",
  "atomic-shim",
- "crossbeam-epoch 0.9.3",
- "crossbeam-utils 0.8.3",
+ "crossbeam-epoch 0.9.5",
+ "crossbeam-utils 0.8.5",
  "dashmap",
  "hashbrown 0.11.2",
  "indexmap",
@@ -776,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.9"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "8c2bdb6314ec10835cd3293dd268473a835c02b7b352e788be788b3c6ca6bb16"
 dependencies = [
  "libc",
  "log",
@@ -789,11 +829,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2 0.3.19",
  "winapi",
 ]
 
@@ -850,16 +889,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.7.2"
+name = "num_enum"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
+checksum = "e5adf0198d427ee515335639f275e806ca01acf9f07d7cf14bb36a10532a6169"
+dependencies = [
+ "derivative",
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1def5a3f69d4707d8a040b12785b98029a39e8c610ae685c7f6265669767482"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "ordered-float"
-version = "2.1.1"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "766f840da25490628d8e63e529cd21c014f6600c6b8517add12a6fa6167a6218"
+checksum = "039f02eb0f69271f26abe3202189275d7aa2258b903cb0281b5de710a2570ff3"
 dependencies = [
  "num-traits",
 ]
@@ -911,9 +972,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
+checksum = "8d31d11c69a6b52a174b42bdc0c30e5e11670f90788b2c471c31c1d17d449443"
 
 [[package]]
 name = "pin-utils"
@@ -922,10 +983,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
+
+[[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger 0.7.1",
+ "log",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fdbd1df62156fbc5945f4762632564d7d038153091c3fcf1067f6aef7cff92"
+dependencies = [
+ "thiserror",
+ "toml",
+]
 
 [[package]]
 name = "proc-macro-hack"
@@ -941,9 +1028,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "5c7ed8b8c7b886ea3ed7dde405212185f423ab44682667c8c6dd14aa1d9f6612"
 dependencies = [
  "unicode-xid",
 ]
@@ -974,12 +1061,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quickcheck"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger",
+ "env_logger 0.8.4",
  "log",
  "rand",
 ]
@@ -1017,9 +1110,9 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1027,27 +1120,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
 ]
 
 [[package]]
 name = "rand_hc"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
 dependencies = [
  "rand_core",
 ]
 
 [[package]]
 name = "raw-cpuid"
-version = "9.0.0"
+version = "9.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c27cb5785b85bd05d4eb171556c9a1a514552e26123aeae6bb7d811353148026"
+checksum = "1733f6f80c9c24268736a501cd00d41a9849b4faa7a9f9334c096e5d10553206"
 dependencies = [
  "bitflags",
 ]
@@ -1072,37 +1165,63 @@ checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
 dependencies = [
  "crossbeam-channel 0.5.1",
  "crossbeam-deque 0.8.0",
- "crossbeam-utils 0.8.3",
+ "crossbeam-utils 0.8.5",
  "lazy_static",
  "num_cpus",
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.5"
+name = "rdkafka"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+checksum = "af78bc431a82ef178c4ad6db537eb9cc25715a8591d27acc30455ee7227a76f4"
+dependencies = [
+ "futures",
+ "libc",
+ "log",
+ "rdkafka-sys",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "slab",
+]
+
+[[package]]
+name = "rdkafka-sys"
+version = "4.0.0+1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f24572851adfeb525fdc4a1d51185898e54fed4e8d8dba4fadb90c6b4f0422"
+dependencies = [
+ "libc",
+ "num_enum",
+ "pkg-config",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ab49abadf3f9e1c4bc499e8845e152ad87d2ad2d30371841171169e9d75feee"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "rustc_version"
@@ -1179,26 +1298,15 @@ checksum = "76a77a8fd93886010f05e7ea0720e569d6d16c65329dbe3ec033bbbccccb017b"
 
 [[package]]
 name = "slab"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
+checksum = "f173ac3d1a7e3b28003f40de0b5ce7fe2710f9b9dc3fc38664cebee46b3b6527"
 
 [[package]]
 name = "smallvec"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
-
-[[package]]
-name = "socket2"
-version = "0.3.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "winapi",
-]
 
 [[package]]
 name = "socket2"
@@ -1212,9 +1320,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "1873d832550d4588c3dbc20f01361ab00bfe741048f71e3fecf145a7cc18b29c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1234,19 +1342,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.24"
+name = "termcolor"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1254,19 +1371,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
 name = "tokio"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
+checksum = "4b7b349f11a7047e6d1276853e612d152f5e8a352c61917887cc2169e2366b4c"
 dependencies = [
  "autocfg",
  "bytes",
@@ -1281,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1342,9 +1450,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
+checksum = "09adeb8c97449311ccd28a427f96fb563e7fd31aabf994189879d9da2394b89d"
 dependencies = [
  "cfg-if 1.0.0",
  "pin-project-lite",
@@ -1365,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
+checksum = "a9ff14f98b1a4b289c6248a023c1c2fa1491062964e9fed67ab29c4e4da4a052"
 dependencies = [
  "lazy_static",
 ]
@@ -1380,21 +1488,21 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "utf8-width"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9071ac216321a4470a69fb2b28cfc68dcd1a39acd877c8be8e014df6772d8efa"
+checksum = "7cf7d77f457ef8dfa11e4cd5933c5ddb5dc52a94664071951219a97710f0a32b"
 
 [[package]]
 name = "version_check"
@@ -1433,6 +1541,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/lading_generators/Cargo.toml
+++ b/lading_generators/Cargo.toml
@@ -70,7 +70,17 @@ version = "0.6"
 default-features = false
 features = ["tokio-exporter"]
 
+[dependencies.pretty_env_logger]
+version = "0.4"
+default-features = false
+features = []
+
 [dependencies.rand]
 version = "0.8"
+default-features = false
+features = []
+
+[dependencies.rdkafka]
+version = "0.26.0"
 default-features = false
 features = []

--- a/lading_generators/src/bin/kafka_gen.rs
+++ b/lading_generators/src/bin/kafka_gen.rs
@@ -1,0 +1,61 @@
+use argh::FromArgs;
+use futures::stream::{FuturesUnordered, StreamExt};
+use lading_generators::kafka_gen::config::{Config, Target};
+use lading_generators::kafka_gen::Worker;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use std::collections::HashMap;
+use std::io::Read;
+use std::net::SocketAddr;
+use tokio::runtime::Builder;
+
+#[derive(FromArgs)]
+/// `kafka_gen` options
+struct Opts {
+    /// path on disk to the configuration file
+    #[argh(option)]
+    config_path: String,
+}
+
+async fn run(addr: SocketAddr, targets: HashMap<String, Target>) {
+    let _: () = PrometheusBuilder::new()
+        .listen_address(addr)
+        .install()
+        .unwrap();
+
+    let mut workers = FuturesUnordered::new();
+
+    targets
+        .into_iter()
+        .map(|(name, target)| Worker::new(name, target).unwrap())
+        .for_each(|worker| workers.push(worker.spin()));
+
+    loop {
+        if let Some(res) = workers.next().await {
+            res.unwrap();
+        }
+    }
+}
+
+fn get_config() -> Config {
+    let ops: Opts = argh::from_env();
+    let mut file: std::fs::File = std::fs::OpenOptions::new()
+        .read(true)
+        .open(ops.config_path)
+        .unwrap();
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+    toml::from_str(&contents).unwrap()
+}
+
+fn main() {
+    pretty_env_logger::init();
+
+    let config: Config = get_config();
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(config.worker_threads as usize)
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(run(config.prometheus_addr, config.targets));
+}

--- a/lading_generators/src/kafka_gen.rs
+++ b/lading_generators/src/kafka_gen.rs
@@ -1,0 +1,8 @@
+//! The `kafka_gen` library
+//!
+//! This crate is intended to back the `kafka_gen` executable and is
+//! not considered useful otherwise.
+
+pub use worker::Worker;
+pub mod config;
+mod worker;

--- a/lading_generators/src/kafka_gen/config.rs
+++ b/lading_generators/src/kafka_gen/config.rs
@@ -16,7 +16,7 @@ pub struct Config {
 }
 
 /// The throughput configuration
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Copy, Debug, Deserialize)]
 #[serde(tag = "type")]
 pub enum Throughput {
     /// The producer should run as fast as possible.

--- a/lading_generators/src/kafka_gen/config.rs
+++ b/lading_generators/src/kafka_gen/config.rs
@@ -1,0 +1,65 @@
+//! This module controls configuration parsing from the end user, providing a
+//! convenience mechanism for the rest of the program. Crashes are most likely
+//! to originate from this code, intentionally.
+use serde::Deserialize;
+use std::{collections::HashMap, net::SocketAddr};
+
+/// Main configuration struct for this program
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    /// Total number of worker thread to use in this program
+    pub worker_threads: u16,
+    /// Address and port for prometheus exporter
+    pub prometheus_addr: SocketAddr,
+    /// The [`Target`] instances and their base name
+    pub targets: HashMap<String, Target>,
+}
+
+/// The throughput configuration
+#[derive(Clone, Debug, Deserialize)]
+#[serde(tag = "type")]
+pub enum Throughput {
+    /// The producer should run as fast as possible.
+    Unlimited,
+    /// The producer is limited to sending a certain number of bytes every second.
+    BytesPerSecond {
+        /// Number of bytes.
+        amount: byte_unit::Byte,
+    },
+    /// The producer is limited to sending a certain number of messages every second.
+    MessagesPerSecond {
+        /// Number of messages.
+        amount: u32,
+    },
+}
+
+/// Variant of the [`TargetTemplate`]
+#[derive(Clone, Copy, Debug, Deserialize)]
+pub enum Variant {
+    /// Generates Datadog Logs JSON messages
+    DatadogLog,
+    /// Generates a limited subset of FoundationDB logs
+    FoundationDb,
+    /// Generates a line of printable ascii characters
+    Ascii,
+    /// Generates a json encoded line
+    Json,
+}
+
+/// The [`Target`] instance from which to derive workers
+#[derive(Clone, Debug, Deserialize)]
+pub struct Target {
+    /// Bootstrap server for Kafka.  Used identically like the flag of the same
+    /// name present on Kafka CLI tooling.
+    pub bootstrap_server: String,
+    /// Topic to produce to.
+    pub topic: String,
+    /// The payload generator to use for this target
+    pub variant: Variant,
+    /// The throughput configuration
+    pub throughput: Throughput,
+    /// The maximum size in bytes of the cache of prebuilt messages
+    pub maximum_prebuild_cache_size_bytes: byte_unit::Byte,
+    /// Map of rdkafka=-specific overrides to apply to the producer
+    pub producer_config: Option<HashMap<String, String>>,
+}

--- a/lading_generators/src/kafka_gen/worker.rs
+++ b/lading_generators/src/kafka_gen/worker.rs
@@ -1,0 +1,202 @@
+use crate::kafka_gen::config::Throughput;
+use crate::kafka_gen::config::{Target, Variant};
+use governor::state::direct::{self, InsufficientCapacity};
+use governor::{clock, state, Quota, RateLimiter};
+use lading_common::block::{self, chunk_bytes, construct_block_cache, Block};
+use lading_common::payload;
+use metrics::{counter, increment_counter};
+use rdkafka::config::FromClientConfig;
+use rdkafka::producer::{FutureProducer, FutureRecord};
+use rdkafka::util::Timeout;
+use rdkafka::ClientConfig;
+use std::num::NonZeroU32;
+
+#[derive(Debug)]
+pub enum Error {
+    Governor(InsufficientCapacity),
+    Io(::std::io::Error),
+    Block(block::Error),
+    Kafka(rdkafka::error::KafkaError),
+    MpscClosed,
+}
+
+impl From<block::Error> for Error {
+    fn from(error: block::Error) -> Self {
+        Error::Block(error)
+    }
+}
+
+impl From<rdkafka::error::KafkaError> for Error {
+    fn from(error: rdkafka::error::KafkaError) -> Self {
+        Error::Kafka(error)
+    }
+}
+
+impl From<InsufficientCapacity> for Error {
+    fn from(error: InsufficientCapacity) -> Self {
+        Error::Governor(error)
+    }
+}
+
+impl From<::std::io::Error> for Error {
+    fn from(error: ::std::io::Error) -> Self {
+        Error::Io(error)
+    }
+}
+
+const ONE_MEBIBYTE: usize = 1_000_000;
+const BLOCK_BYTE_SIZES: [usize; 8] = [
+    ONE_MEBIBYTE / 1024,
+    ONE_MEBIBYTE / 512,
+    ONE_MEBIBYTE / 256,
+    ONE_MEBIBYTE / 128,
+    ONE_MEBIBYTE / 64,
+    ONE_MEBIBYTE / 32,
+    ONE_MEBIBYTE / 16,
+    ONE_MEBIBYTE / 8,
+];
+
+/// The [`Worker`] defines a task that emits variant lines to an HTTP server
+/// controlling throughput.
+#[derive(Debug)]
+pub struct Worker {
+    name: String,
+    target: Target,
+    block_cache: Vec<Block>,
+    labels: Vec<(String, String)>,
+}
+
+impl Worker {
+    /// Create a new [`Worker`] instance
+    ///
+    /// # Errors
+    ///
+    /// Creation will fail if the underlying governor capacity exceeds u32.
+    ///
+    /// # Panics
+    ///
+    /// Function will panic if user has passed non-zero values for any byte
+    /// values. Sharp corners.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn new(name: String, target: Target) -> Result<Self, Error> {
+        let labels = vec![
+            ("name".to_string(), name.clone()),
+            ("server".to_string(), target.bootstrap_server.to_string()),
+        ];
+
+        let block_cache = generate_block_cache(
+            target.maximum_prebuild_cache_size_bytes,
+            target.variant,
+            &labels,
+        );
+
+        Ok(Self {
+            name,
+            target,
+            block_cache,
+            labels,
+        })
+    }
+
+    /// Enter the main loop of this [`Worker`]
+    ///
+    /// # Errors
+    ///
+    /// TODO
+    ///
+    /// # Panics
+    ///
+    /// Function will panic if it is unable to produce messages to the target Kafka cluster.
+    pub async fn spin(self) -> Result<(), Error> {
+        // Configure our Kafka producer.
+        let bootstrap_server = self.target.bootstrap_server;
+        let topic = self.target.topic;
+        let labels = self.labels;
+
+        let mut client_config = ClientConfig::new();
+        let mut config_values = self.target.producer_config.unwrap_or_default();
+        config_values.insert("bootstrap.servers".to_string(), bootstrap_server);
+        for (k, v) in config_values.drain() {
+            client_config.set(k, v);
+        }
+
+        let producer = FutureProducer::from_config(&client_config)?;
+
+        // Configure our rate limiter.
+        let limit_by_bytes = matches!(self.target.throughput, Throughput::BytesPerSecond { .. });
+        let rate_limiter = get_rate_limiter(self.target.throughput);
+
+        // Now produce our messages.
+        let mut blocks = self.block_cache.iter().cycle();
+        loop {
+            let block = blocks.next().expect("should never be empty");
+            let block_size = block.bytes.len() as u64;
+            let limiter_n = if limit_by_bytes { block_size as u32 } else { 1 };
+            let limiter_n = NonZeroU32::new(limiter_n).expect("should never be zero");
+
+            let _ = rate_limiter.until_n_ready(limiter_n).await;
+            let record = FutureRecord::to(topic.as_ref())
+                .payload(&block.bytes)
+                .key(&());
+
+            let result = producer.send(record, Timeout::Never).await;
+            counter!("requests_sent", 1, &labels);
+            match result {
+                Ok(..) => {
+                    increment_counter!("request_ok", &labels);
+                    counter!("bytes_written", block_size, &labels);
+                }
+                Err(..) => {
+                    counter!("request_failure", 1, &labels);
+                }
+            }
+        }
+    }
+}
+
+fn generate_block_cache(
+    cache_size: byte_unit::Byte,
+    variant: Variant,
+    labels: &Vec<(String, String)>,
+) -> Vec<Block> {
+    let mut rng = rand::thread_rng();
+
+    let chunks = chunk_bytes(&mut rng, cache_size.get_bytes() as usize, &BLOCK_BYTE_SIZES);
+
+    match variant {
+        Variant::Ascii => construct_block_cache(&payload::Ascii::default(), &chunks, &labels),
+        Variant::DatadogLog => {
+            construct_block_cache(&payload::DatadogLog::default(), &chunks, &labels)
+        }
+        Variant::Json => construct_block_cache(&payload::Json::default(), &chunks, &labels),
+        Variant::FoundationDb => {
+            construct_block_cache(&payload::FoundationDb::default(), &chunks, &labels)
+        }
+    }
+}
+
+fn get_rate_limiter(
+    throughput: Throughput,
+) -> RateLimiter<direct::NotKeyed, state::InMemoryState, clock::QuantaClock> {
+    match throughput {
+        Throughput::Unlimited => {
+            let amount = NonZeroU32::new(u32::MAX).expect("amount should not be zero");
+            RateLimiter::direct(Quota::per_second(amount))
+        }
+        Throughput::BytesPerSecond { amount } => {
+            let amount = if amount.get_bytes() == 0 {
+                1
+            } else {
+                amount.get_bytes() as u32
+            };
+            let amount = NonZeroU32::new(amount).expect("amount should not be zero");
+            RateLimiter::direct(Quota::per_second(amount))
+        }
+        Throughput::MessagesPerSecond { amount } => {
+            let amount = if amount == 0 { 1 } else { amount as u32 };
+            let amount = NonZeroU32::new(amount).expect("amount should not be zero");
+
+            RateLimiter::direct(Quota::per_second(amount))
+        }
+    }
+}

--- a/lading_generators/src/lib.rs
+++ b/lading_generators/src/lib.rs
@@ -8,3 +8,4 @@
 
 pub mod file_gen;
 pub mod http_gen;
+pub mod kafka_gen;


### PR DESCRIPTION
Closes #65 

Introduces a new generator -- `kafka_gen` -- which produces messages to Kafka.  This first cut does not address any sort of parallelization of producers, since we should be able to hit modest throughput rates even with a single producer task.

We've added support to precache blocks, can generate all of the existing data variants, etc etc, and allow for multiple producer targets, similar to `http_gen`, which maps, essentially, to a specific Kafka server (cluster, really) and topic combination.