### PR TITLE
Speed up kafka_gen maximum throughput by batching.

### DIFF
--- a/lading_common/src/payload/datadog_logs.rs
+++ b/lading_common/src/payload/datadog_logs.rs
@@ -96,7 +96,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Source {
     }
 }
 
-const TAG_OPTIONS: [&'static str; 4] = ["", "env:prod", "env:dev", "env:prod,version:1.1"];
+const TAG_OPTIONS: [&str; 4] = ["", "env:prod", "env:dev", "env:prod,version:1.1"];
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Structured {


### PR DESCRIPTION
Currently, the worker code for `kafka_gen` does a synchronous send loop: send a request, wait for `rdkafka` to take it and send it, and then loop back around.  This is slow.  We can do like 3-4MB/second this way, tops, per thread.

Now, instead, we perform a core loop of sending messages, without awaiting their actual send to the cluster, until `rdkafka`'s internal send queue is full.  Once that happens, we try and drive any of the delivery futures to completion before looping back around and saturating the send queue once again.  In this way, we can easily send 400 to 500MB/second with a single task, which should be more than enough for any Vector soak tests we wish to run.