### PR TITLE
Introduce `tcp_gen`, fluent payload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,7 @@ jobs:
           target/release/file_gen
           target/release/http_gen
           target/release/kafka_gen
+          target/release/tcp_gen
           target/release/http_blackhole
           target/release/udp_blackhole
       env:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72feb31ffc86498dacdbd0fcebb56138e7177a8cc5cea4516031d15ae85a742e"
 
 [[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+
+[[package]]
 name = "bytes"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -643,8 +649,10 @@ dependencies = [
  "metrics",
  "quickcheck",
  "rand",
+ "rmp-serde",
  "serde",
  "serde_json",
+ "serde_tuple",
 ]
 
 [[package]]
@@ -1213,6 +1221,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "rmp"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f55e5fa1446c4d5dd1f5daeed2a4fe193071771a2636274d0d7a3b082aa7ad6"
+dependencies = [
+ "byteorder",
+ "num-traits",
+]
+
+[[package]]
+name = "rmp-serde"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "723ecff9ad04f4ad92fe1c8ca6c20d2196d9286e9c60727c4cb5511629260e9d"
+dependencies = [
+ "byteorder",
+ "rmp",
+ "serde",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1253,6 +1282,27 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_tuple"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4f025b91216f15a2a32aa39669329a475733590a015835d1783549a56d09427"
+dependencies = [
+ "serde",
+ "serde_tuple_macros",
+]
+
+[[package]]
+name = "serde_tuple_macros"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4076151d1a2b688e25aaf236997933c66e18b870d0369f8b248b8ab2be630d7e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -636,6 +636,9 @@ dependencies = [
  "hyper",
  "metrics",
  "metrics-exporter-prometheus",
+ "once_cell",
+ "serde",
+ "serde_json",
  "tokio",
  "tower",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [profile.release]
-lto = true        # Optimize our binary at link stage.
-codegen-units = 1 # Increases compile time but improves optmization alternatives.
-opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.
+# lto = true        # Optimize our binary at link stage.
+# codegen-units = 1 # Increases compile time but improves optmization alternatives.
+# opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 ]
 
 [profile.release]
-# lto = true        # Optimize our binary at link stage.
-# codegen-units = 1 # Increases compile time but improves optmization alternatives.
-# opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.
+lto = true        # Optimize our binary at link stage.
+codegen-units = 1 # Increases compile time but improves optmization alternatives.
+opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.
 debug = true

--- a/lading_blackholes/Cargo.toml
+++ b/lading_blackholes/Cargo.toml
@@ -24,10 +24,24 @@ version = "0.14"
 default-features = false
 features = ["http2", "tcp"]
 
+[dependencies.serde]
+version = "1.0"
+default-features = false
+features = ["derive", "std"]
+
+[dependencies.serde_json]
+version = "1.0"
+default-features = false
+features = ["std"]
+
 [dependencies.tokio]
 version = "1.9"
 default-features = false
 features = ["rt", "rt-multi-thread", "macros", "fs", "io-util"]
+
+[dependencies.once_cell]
+version = "1.8"
+default-features = false
 
 [[bin]]
 name = "udp_blackhole"

--- a/lading_blackholes/src/bin/http_blackhole.rs
+++ b/lading_blackholes/src/bin/http_blackhole.rs
@@ -128,7 +128,6 @@ impl HttpServer {
         }
     }
 
-    #[allow(clippy::borrow_interior_mutable_const)]
     async fn run(
         self,
         body_variant: BodyVariant,

--- a/lading_common/Cargo.toml
+++ b/lading_common/Cargo.toml
@@ -22,10 +22,18 @@ version = "1"
 default-features = false
 features = ["derive"]
 
+[dependencies.rmp-serde]
+version = "0.15"
+default-features = false
+
 [dependencies.serde]
 version = "1.0"
 default-features = true
 features = ["derive", "std"]
+
+[dependencies.serde_tuple]
+version = "0.5"
+default-features = false
 
 [dependencies.serde_json]
 version = "1.0"

--- a/lading_common/src/payload.rs
+++ b/lading_common/src/payload.rs
@@ -3,12 +3,14 @@ use std::io::{self, Write};
 mod ascii;
 mod common;
 mod datadog_logs;
+mod fluent;
 mod foundationdb;
 mod json;
 mod statik;
 
 pub use ascii::Ascii;
 pub use datadog_logs::DatadogLog;
+pub use fluent::Fluent;
 pub use foundationdb::FoundationDb;
 pub use json::Json;
 use rand::Rng;
@@ -17,12 +19,20 @@ pub use statik::Static;
 /// Errors related to serialization
 #[derive(Debug)]
 pub enum Error {
+    /// MsgPack payload could not be encoded
+    MsgPack(rmp_serde::encode::Error),
     /// Json payload could not be encoded
     Json(serde_json::Error),
     /// IO operation failed
     Io(io::Error),
     /// Arbitrary instance could not be created
     Arbitrary(arbitrary::Error),
+}
+
+impl From<rmp_serde::encode::Error> for Error {
+    fn from(error: rmp_serde::encode::Error) -> Self {
+        Error::MsgPack(error)
+    }
 }
 
 impl From<serde_json::Error> for Error {

--- a/lading_common/src/payload/datadog_logs.rs
+++ b/lading_common/src/payload/datadog_logs.rs
@@ -231,15 +231,17 @@ impl Serialize for DatadogLog {
         rng.fill_bytes(&mut entropy);
         let unstructured = Unstructured::new(&entropy);
 
-        let mut members = <Vec<Member> as arbitrary::Arbitrary>::arbitrary_take_rest(unstructured)?;
+        let members = <Vec<Member> as arbitrary::Arbitrary>::arbitrary_take_rest(unstructured)?;
+        let low = 0;
+        let mut high = members.len();
+
         loop {
-            let encoding = serde_json::to_string(&members)?;
-            if encoding.len() < max_bytes {
-                let encoding = serde_json::to_string(&members)?;
+            let encoding = serde_json::to_string(&members[low..high])?;
+            if encoding.len() > max_bytes {
+                high /= 2;
+            } else {
                 write!(writer, "{}", encoding)?;
                 break;
-            } else {
-                members.pop();
             }
         }
         Ok(())

--- a/lading_common/src/payload/datadog_logs.rs
+++ b/lading_common/src/payload/datadog_logs.rs
@@ -96,7 +96,7 @@ impl<'a> arbitrary::Arbitrary<'a> for Source {
     }
 }
 
-const TAG_OPTIONS: [&'static str; 4] = ["", "env:prod", "env:dev", "env:prod,version:1.1"];
+const TAG_OPTIONS: [&str; 4] = ["", "env:prod", "env:dev", "env:prod,version:1.1"];
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Structured {

--- a/lading_common/src/payload/fluent.rs
+++ b/lading_common/src/payload/fluent.rs
@@ -18,7 +18,7 @@ enum RecordValue {
     Object(HashMap<String, u8>),
 }
 
-fn object<'a>(u: &mut Unstructured<'a>) -> arbitrary::Result<RecordValue> {
+fn object(u: &mut Unstructured<'_>) -> arbitrary::Result<RecordValue> {
     let mut obj = HashMap::new();
     for _ in 0..u.arbitrary_len::<(AsciiStr, u8)>()? {
         let key = u.arbitrary::<AsciiStr>()?;
@@ -48,7 +48,7 @@ impl<'a> arbitrary::Arbitrary<'a> for RecordValue {
     }
 }
 
-fn record<'a>(u: &mut Unstructured<'a>) -> arbitrary::Result<HashMap<String, RecordValue>> {
+fn record(u: &mut Unstructured<'_>) -> arbitrary::Result<HashMap<String, RecordValue>> {
     let mut record = HashMap::new();
 
     let msg = u.arbitrary::<AsciiStr>()?;

--- a/lading_common/src/payload/fluent.rs
+++ b/lading_common/src/payload/fluent.rs
@@ -1,0 +1,201 @@
+//! Implements [this
+//! protocol](https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1).
+use super::common::AsciiStr;
+use crate::payload::{Error, Serialize};
+use arbitrary::size_hint;
+use arbitrary::Unstructured;
+use rand::Rng;
+use serde_tuple::Serialize_tuple;
+use std::{collections::HashMap, io::Write};
+
+#[derive(Debug, Default)]
+pub struct Fluent {}
+
+fn record<'a>(u: &mut Unstructured<'a>) -> arbitrary::Result<HashMap<String, String>> {
+    let mut record = HashMap::new();
+
+    let msg = u.arbitrary::<AsciiStr>()?;
+    record.insert("message".to_string(), msg.as_str().to_string());
+
+    // for _ in 0..u.arbitrary_len::<(AsciiStr, AsciiStr)>()? {
+    //     let key = u.arbitrary::<AsciiStr>()?;
+    //     let msg = u.arbitrary::<AsciiStr>()?;
+
+    //     record.insert(key.as_str().to_string(), msg.as_str().to_string());
+    // }
+    Ok(record)
+}
+
+#[derive(Serialize_tuple)]
+struct Entry {
+    time: u64,
+    record: HashMap<String, String>, // always contains 'message' key
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Entry {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Entry {
+            time: u.arbitrary::<u64>()?,
+            record: record(u)?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        size_hint::recursion_guard(depth, |depth| {
+            size_hint::and_all(&[
+                <AsciiStr as arbitrary::Arbitrary>::size_hint(depth),
+                <HashMap<String, String> as arbitrary::Arbitrary>::size_hint(depth),
+            ])
+        })
+    }
+}
+
+#[derive(Serialize_tuple)]
+struct FluentForward {
+    tag: String,
+    entries: Vec<Entry>,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for FluentForward {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(FluentForward {
+            tag: u.arbitrary::<AsciiStr>()?.as_str().to_string(),
+            entries: u.arbitrary::<Vec<Entry>>()?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        size_hint::recursion_guard(depth, |depth| {
+            size_hint::and_all(&[
+                <AsciiStr as arbitrary::Arbitrary>::size_hint(depth),
+                <Vec<Entry> as arbitrary::Arbitrary>::size_hint(depth),
+            ])
+        })
+    }
+}
+
+#[derive(serde::Serialize)]
+struct FluentMessage {
+    tag: String,
+    time: u64,
+    record: HashMap<String, String>, // always contains 'message' key
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for FluentMessage {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(FluentMessage {
+            tag: "thetag".to_string(), // u.arbitrary::<AsciiStr>()?.as_str().to_string(),
+            time: u.arbitrary::<u64>()?,
+            record: record(u)?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        size_hint::recursion_guard(depth, |depth| {
+            size_hint::and_all(&[
+                <AsciiStr as arbitrary::Arbitrary>::size_hint(depth),
+                <u64 as arbitrary::Arbitrary>::size_hint(depth),
+                <HashMap<String, String> as arbitrary::Arbitrary>::size_hint(depth),
+            ])
+        })
+    }
+}
+
+#[derive(serde::Serialize)]
+#[serde(untagged)]
+enum Member {
+    Message(FluentMessage),
+    //Forward(FluentForward),
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Member {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let choice = u.arbitrary::<u8>()?;
+        let res = match choice % 1 {
+            0 => Member::Message(u.arbitrary::<FluentMessage>()?),
+            //      0 => Member::Forward(u.arbitrary::<FluentForward>()?),
+            _ => unreachable!(),
+        };
+        Ok(res)
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        size_hint::recursion_guard(depth, |depth| {
+            size_hint::and_all(&[
+                <FluentMessage as arbitrary::Arbitrary>::size_hint(depth),
+                // <FluentForward as arbitrary::Arbitrary>::size_hint(depth),
+            ])
+        })
+    }
+}
+
+impl Serialize for Fluent {
+    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    where
+        W: Write,
+        R: Rng + Sized,
+    {
+        if max_bytes < 16 {
+            // 16 is just an arbitrarily big constant
+            return Ok(());
+        }
+
+        let mut entropy: Vec<u8> = vec![0; max_bytes];
+        rng.fill_bytes(&mut entropy);
+        let unstructured = Unstructured::new(&entropy);
+
+        let members = <Vec<Member> as arbitrary::Arbitrary>::arbitrary_take_rest(unstructured)?;
+        let members: Vec<Vec<u8>> = members
+            .into_iter()
+            .map(|m| rmp_serde::to_vec(&m).unwrap())
+            .collect();
+        let low = 0;
+        let mut high = members.len();
+
+        loop {
+            let encoding_len = members[low..high].iter().fold(0, |acc, m| acc + m.len());
+
+            if encoding_len > max_bytes {
+                high /= 2;
+            } else {
+                for m in &members[low..high] {
+                    writer.write_all(m)?;
+                }
+                break;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::payload::{Fluent, Serialize};
+    use quickcheck::{QuickCheck, TestResult};
+    use rand::rngs::SmallRng;
+    use rand::SeedableRng;
+
+    // We want to be sure that the serialized size of the payload does not
+    // exceed `max_bytes`.
+    #[test]
+    fn payload_not_exceed_max_bytes() {
+        fn inner(seed: u64, max_bytes: u16) -> TestResult {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let fluent = Fluent::default();
+
+            let mut bytes = Vec::with_capacity(max_bytes);
+            fluent.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            debug_assert!(
+                bytes.len() <= max_bytes,
+                "{:?}",
+                std::str::from_utf8(&bytes).unwrap()
+            );
+
+            TestResult::passed()
+        }
+        QuickCheck::new()
+            .tests(1_000)
+            .quickcheck(inner as fn(u64, u16) -> TestResult);
+    }
+}

--- a/lading_generators/src/bin/tcp_gen.rs
+++ b/lading_generators/src/bin/tcp_gen.rs
@@ -1,0 +1,59 @@
+use argh::FromArgs;
+use futures::stream::{FuturesUnordered, StreamExt};
+use lading_generators::tcp_gen::config::{Config, Target};
+use lading_generators::tcp_gen::Worker;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use std::collections::HashMap;
+use std::io::Read;
+use std::net::SocketAddr;
+use tokio::runtime::Builder;
+
+#[derive(FromArgs)]
+/// `tcp_gen` options
+struct Opts {
+    /// path on disk to the configuration file
+    #[argh(option)]
+    config_path: String,
+}
+
+async fn run(addr: SocketAddr, targets: HashMap<String, Target>) {
+    let _: () = PrometheusBuilder::new()
+        .listen_address(addr)
+        .install()
+        .unwrap();
+
+    let mut workers = FuturesUnordered::new();
+
+    targets
+        .into_iter()
+        .map(|(name, target)| Worker::new(name, target).unwrap())
+        .for_each(|worker| workers.push(worker.spin()));
+
+    loop {
+        if let Some(res) = workers.next().await {
+            res.unwrap();
+        }
+    }
+}
+
+fn get_config() -> Config {
+    let ops: Opts = argh::from_env();
+    let mut file: std::fs::File = std::fs::OpenOptions::new()
+        .read(true)
+        .open(ops.config_path)
+        .unwrap();
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+    toml::from_str(&contents).unwrap()
+}
+
+fn main() {
+    let config: Config = get_config();
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(config.worker_threads as usize)
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime.block_on(run(config.prometheus_addr, config.targets));
+}

--- a/lading_generators/src/bin/tcp_gen.rs
+++ b/lading_generators/src/bin/tcp_gen.rs
@@ -26,7 +26,7 @@ async fn run(addr: SocketAddr, targets: HashMap<String, Target>) {
 
     targets
         .into_iter()
-        .map(|(name, target)| Worker::new(name, target).unwrap())
+        .map(|(name, target)| Worker::new(name, &target).unwrap())
         .for_each(|worker| workers.push(worker.spin()));
 
     loop {

--- a/lading_generators/src/http_gen/worker.rs
+++ b/lading_generators/src/http_gen/worker.rs
@@ -53,13 +53,6 @@ impl From<::std::io::Error> for Error {
 
 const ONE_MEBIBYTE: usize = 1_000_000;
 const BLOCK_BYTE_SIZES: [usize; 5] = [
-    // ONE_MEBIBYTE / 1024,
-    // ONE_MEBIBYTE / 512,
-    // ONE_MEBIBYTE / 256,
-    // ONE_MEBIBYTE / 128,
-    // ONE_MEBIBYTE / 64,
-    // ONE_MEBIBYTE / 32,
-    // ONE_MEBIBYTE / 16,
     ONE_MEBIBYTE / 8,
     ONE_MEBIBYTE / 4,
     ONE_MEBIBYTE / 2,

--- a/lading_generators/src/lib.rs
+++ b/lading_generators/src/lib.rs
@@ -9,3 +9,4 @@
 pub mod file_gen;
 pub mod http_gen;
 pub mod kafka_gen;
+pub mod tcp_gen;

--- a/lading_generators/src/tcp_gen.rs
+++ b/lading_generators/src/tcp_gen.rs
@@ -1,0 +1,8 @@
+//! The `tcp_gen` library
+//!
+//! This crate is intended to back the `tcp_gen` executable and is
+//! not considered useful otherwise.
+
+pub use worker::Worker;
+pub mod config;
+mod worker;

--- a/lading_generators/src/tcp_gen/config.rs
+++ b/lading_generators/src/tcp_gen/config.rs
@@ -1,0 +1,36 @@
+//! This module controls configuration parsing from the end user, providing a
+//! convenience mechanism for the rest of the program. Crashes are most likely
+//! to originate from this code, intentionally.
+use serde::Deserialize;
+use std::{collections::HashMap, net::SocketAddr};
+
+/// Main configuration struct for this program
+#[derive(Debug, Deserialize)]
+pub struct Config {
+    /// Total number of worker threads to use in this program
+    pub worker_threads: u16,
+    /// Address and port for prometheus exporter
+    pub prometheus_addr: SocketAddr,
+    /// The [`Target`] instances and their base name
+    pub targets: HashMap<String, Target>,
+}
+
+/// Variant of the [`Target`]
+#[derive(Debug, Deserialize)]
+pub enum Variant {
+    /// Generates Fluent messages
+    Fluent,
+}
+
+/// The [`Target`] instance from which to derive workers
+#[derive(Debug, Deserialize)]
+pub struct Target {
+    /// The address for the target, must be a valid SocketAddr
+    pub addr: SocketAddr,
+    /// The payload variant
+    pub variant: Variant,
+    /// The bytes per second to send or receive from the target
+    pub bytes_per_second: byte_unit::Byte,
+    /// The maximum size in bytes of the cache of prebuilt messages
+    pub maximum_prebuild_cache_size_bytes: byte_unit::Byte,
+}

--- a/lading_generators/src/tcp_gen/worker.rs
+++ b/lading_generators/src/tcp_gen/worker.rs
@@ -99,6 +99,10 @@ impl Worker {
         let mut client: TcpStream = TcpStream::connect(self.addr).await.unwrap();
 
         for blk in self.block_cache.iter().cycle() {
+            self.rate_limiter
+                .until_n_ready(blk.total_bytes)
+                .await
+                .unwrap();
             client.write_all(&blk.bytes).await.unwrap();
         }
         unreachable!()

--- a/lading_generators/src/tcp_gen/worker.rs
+++ b/lading_generators/src/tcp_gen/worker.rs
@@ -1,0 +1,106 @@
+use crate::tcp_gen::config::{Target, Variant};
+use governor::state::direct::{self, InsufficientCapacity};
+use governor::{clock, state, Quota, RateLimiter};
+use lading_common::block::{chunk_bytes, construct_block_cache, Block};
+use lading_common::payload;
+use std::net::SocketAddr;
+use std::num::NonZeroU32;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+
+const ONE_MEBIBYTE: usize = 1_000_000;
+const BLOCK_BYTE_SIZES: [usize; 7] = [
+    ONE_MEBIBYTE / 32,
+    ONE_MEBIBYTE / 16,
+    ONE_MEBIBYTE / 8,
+    ONE_MEBIBYTE / 4,
+    ONE_MEBIBYTE / 2,
+    ONE_MEBIBYTE,
+    ONE_MEBIBYTE * 2,
+];
+
+/// The [`Worker`] defines a task that emits variant lines to an HTTP server
+/// controlling throughput.
+#[derive(Debug)]
+pub struct Worker {
+    name: String,
+    addr: SocketAddr,
+    rate_limiter: RateLimiter<direct::NotKeyed, state::InMemoryState, clock::QuantaClock>,
+    block_cache: Vec<Block>,
+    metric_labels: Vec<(String, String)>,
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Governor(InsufficientCapacity),
+    // Io(::std::io::Error),
+    // Block(block::Error),
+    // Hyper(hyper::Error),
+    // Http(hyper::http::Error),
+}
+
+impl From<InsufficientCapacity> for Error {
+    fn from(error: InsufficientCapacity) -> Self {
+        Error::Governor(error)
+    }
+}
+
+impl Worker {
+    /// Create a new [`Worker`] instance
+    ///
+    /// # Errors
+    ///
+    /// Creation will fail if the underlying governor capacity exceeds u32.
+    ///
+    /// # Panics
+    ///
+    /// Function will panic if user has passed non-zero values for any byte
+    /// values. Sharp corners.
+    #[allow(clippy::cast_possible_truncation)]
+    pub fn new(name: String, target: Target) -> Result<Self, Error> {
+        let mut rng = rand::thread_rng();
+        let bytes_per_second = NonZeroU32::new(target.bytes_per_second.get_bytes() as u32).unwrap();
+        let rate_limiter = RateLimiter::direct(Quota::per_second(bytes_per_second));
+        let labels = vec![
+            ("name".to_string(), name.clone()),
+            ("target".to_string(), target.addr.to_string()),
+        ];
+        let block_chunks = chunk_bytes(
+            &mut rng,
+            target.maximum_prebuild_cache_size_bytes.get_bytes() as usize,
+            &BLOCK_BYTE_SIZES,
+        );
+        let block_cache = match target.variant {
+            Variant::Fluent => {
+                construct_block_cache(&payload::Fluent::default(), &block_chunks, &labels)
+            }
+        };
+
+        Ok(Self {
+            addr: target.addr,
+            block_cache,
+            name,
+            rate_limiter,
+            metric_labels: labels,
+        })
+    }
+
+    /// Enter the main loop of this [`Worker`]
+    ///
+    /// # Errors
+    ///
+    /// TODO
+    ///
+    /// # Panics
+    ///
+    /// Function will panic if it is unable to create HTTP requests for the
+    /// target.
+    pub async fn spin(self) -> Result<(), Error> {
+        let mut client: TcpStream = TcpStream::connect(self.addr).await.unwrap();
+
+        for blk in self.block_cache.iter().cycle() {
+            client.write_all(&blk.bytes).await.unwrap();
+        }
+        unreachable!()
+    }
+}

--- a/lading_generators/src/tcp_gen/worker.rs
+++ b/lading_generators/src/tcp_gen/worker.rs
@@ -57,7 +57,7 @@ impl Worker {
     /// Function will panic if user has passed non-zero values for any byte
     /// values. Sharp corners.
     #[allow(clippy::cast_possible_truncation)]
-    pub fn new(name: String, target: Target) -> Result<Self, Error> {
+    pub fn new(name: String, target: &Target) -> Result<Self, Error> {
         let mut rng = rand::thread_rng();
         let bytes_per_second = NonZeroU32::new(target.bytes_per_second.get_bytes() as u32).unwrap();
         let rate_limiter = RateLimiter::direct(Quota::per_second(bytes_per_second));


### PR DESCRIPTION
This PR introduces a new generator for TCP and a new payload, fluent. The TCP generator at present only supports fluent payloads, though this is easy to modify in the future if we desire. I have not included the wide-open bytes-per-second configuration option that `kafka_gen` has, though I think we probably do want to spread that across all the generators. As with `http_gen` the `tcp_gen` will keep pace with its target and unlike `http_gen` only has a single connection at present. 

