### PR TITLE
Generate Syslog5424

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "chrono"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670ad68c9088c2a963aaa298cb369688cf3f9465ce5e2d4ca10e6e0098a1ce73"
+dependencies = [
+ "libc",
+ "num-integer",
+ "num-traits",
+ "time",
+ "winapi",
+]
+
+[[package]]
 name = "crossbeam"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,7 +643,7 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "lading_blackholes"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "argh",
  "hyper",
@@ -645,10 +658,11 @@ dependencies = [
 
 [[package]]
 name = "lading_common"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "arbitrary",
  "bytecount",
+ "chrono",
  "metrics",
  "quickcheck",
  "rand",
@@ -660,7 +674,7 @@ dependencies = [
 
 [[package]]
 name = "lading_generators"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "argh",
  "byte-unit",
@@ -867,6 +881,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f6bb902e437b6d86e03cce10a7e2af662292c5dfef23b65899ea3ac9354ad44"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -1374,6 +1398,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]

--- a/lading_common/Cargo.toml
+++ b/lading_common/Cargo.toml
@@ -11,6 +11,7 @@ description = "A set of code for data generation and blocking."
 
 [dependencies]
 bytecount = "0.6"
+chrono = "0.4"
 
 [dependencies.metrics]
 version = "0.17"

--- a/lading_common/src/payload.rs
+++ b/lading_common/src/payload.rs
@@ -7,6 +7,7 @@ mod fluent;
 mod foundationdb;
 mod json;
 mod statik;
+mod syslog;
 
 pub use ascii::Ascii;
 pub use datadog_logs::DatadogLog;
@@ -15,6 +16,7 @@ pub use foundationdb::FoundationDb;
 pub use json::Json;
 use rand::Rng;
 pub use statik::Static;
+pub use syslog::Syslog5424;
 
 /// Errors related to serialization
 #[derive(Debug)]

--- a/lading_common/src/payload/syslog.rs
+++ b/lading_common/src/payload/syslog.rs
@@ -1,0 +1,183 @@
+use crate::payload::{Error, Serialize};
+use arbitrary::{size_hint, Unstructured};
+use chrono::{prelude::Local, SecondsFormat};
+use rand::Rng;
+use std::io::Write;
+
+#[derive(Debug, Default)]
+pub struct Syslog5424 {}
+
+const HOSTNAMES: [&str; 4] = [
+    "troutwine.us",
+    "vector.dev",
+    "skullmountain.us",
+    "zombo.com",
+];
+const APP_NAMES: [&str; 4] = ["vector", "cernan", "lading", "execsnoop"];
+
+#[derive(serde::Serialize)]
+struct Message {
+    eccentricity: u32,
+    semimajor_axis: u32,
+    inclination: f32,
+    longitude_of_ascending_node: u32,
+    periapsis: u64,
+    true_anomaly: u8,
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Message {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        Ok(Message {
+            eccentricity: u.arbitrary::<u32>()?,
+            semimajor_axis: u.arbitrary::<u32>()?,
+            inclination: u.arbitrary::<f32>()?,
+            longitude_of_ascending_node: u.arbitrary::<u32>()?,
+            periapsis: u.arbitrary::<u64>()?,
+            true_anomaly: u.arbitrary::<u8>()?,
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        size_hint::recursion_guard(depth, |depth| {
+            size_hint::and_all(&[
+                <u32 as arbitrary::Arbitrary>::size_hint(depth),
+                <u32 as arbitrary::Arbitrary>::size_hint(depth),
+                <f32 as arbitrary::Arbitrary>::size_hint(depth),
+                <u32 as arbitrary::Arbitrary>::size_hint(depth),
+                <u64 as arbitrary::Arbitrary>::size_hint(depth),
+                <u8 as arbitrary::Arbitrary>::size_hint(depth),
+            ])
+        })
+    }
+}
+
+struct Member {
+    priority: u8,       // 0 - 191
+    syslog_version: u8, // 1 - 3
+    timestamp: String,  // seconds format in millis
+    hostname: String,   // name.tld
+    app_name: String,   // shortish string
+    procid: u16,        // 100 - 9999
+    msgid: u16,         // 1 - 999
+    message: String,    // shortish structured string
+}
+
+impl<'a> arbitrary::Arbitrary<'a> for Member {
+    fn arbitrary(u: &mut Unstructured<'a>) -> arbitrary::Result<Self> {
+        let priority = u.arbitrary::<u8>()? % 191;
+        let syslog_version = (u.arbitrary::<u8>()? % 3) + 1;
+        let timestamp = Local::now().to_rfc3339_opts(SecondsFormat::Millis, true);
+        let hostname_idx = u.arbitrary::<usize>()? % HOSTNAMES.len();
+        let app_name_idx = u.arbitrary::<usize>()? % APP_NAMES.len();
+        let procid = (u.arbitrary::<u16>()? % 9899) + 101;
+        let msgid = (u.arbitrary::<u16>()? % 999) + 1;
+        let message = u.arbitrary::<Message>()?;
+
+        Ok(Member {
+            priority,
+            syslog_version,
+            timestamp,
+            hostname: HOSTNAMES[hostname_idx as usize].to_string(),
+            app_name: APP_NAMES[app_name_idx as usize].to_string(),
+            procid,
+            msgid,
+            message: serde_json::to_string(&message).unwrap(),
+        })
+    }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        size_hint::recursion_guard(depth, |depth| {
+            size_hint::and_all(&[
+                <u8 as arbitrary::Arbitrary>::size_hint(depth),
+                <u8 as arbitrary::Arbitrary>::size_hint(depth),
+                (16, Some(64)), // timestamp
+                (8, Some(16)),  // hostnames
+                (4, Some(20)),  // app names
+                <u16 as arbitrary::Arbitrary>::size_hint(depth),
+                <u16 as arbitrary::Arbitrary>::size_hint(depth),
+                (128, Some(512)), // message
+            ])
+        })
+    }
+}
+
+impl Member {
+    fn into_string(self) -> String {
+        format!(
+            "<{}>{} {} {} {} {} ID{} - {}",
+            self.priority,
+            self.syslog_version,
+            self.timestamp,
+            self.hostname,
+            self.app_name,
+            self.procid,
+            self.msgid,
+            self.message
+        )
+    }
+}
+
+impl Serialize for Syslog5424 {
+    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+    where
+        R: Rng + Sized,
+        W: Write,
+    {
+        if max_bytes < 2 {
+            // 'empty' payload  is []
+            return Ok(());
+        }
+
+        let mut entropy: Vec<u8> = vec![0; max_bytes];
+        rng.fill_bytes(&mut entropy);
+        let unstructured = Unstructured::new(&entropy);
+
+        let members = <Vec<Member> as arbitrary::Arbitrary>::arbitrary_take_rest(unstructured)?;
+        let encoded = members.into_iter().map(|m| m.into_string());
+
+        let mut written_bytes = 0;
+        for line in encoded.into_iter() {
+            if line.len() + 1 + written_bytes > max_bytes {
+                break;
+            }
+
+            writeln!(writer, "{}", line)?;
+
+            written_bytes += 1; // newline
+            written_bytes += line.len();
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::payload::{Serialize, Syslog5424};
+    use quickcheck::{QuickCheck, TestResult};
+    use rand::rngs::SmallRng;
+    use rand::SeedableRng;
+
+    // We want to be sure that the serialized size of the payload does not
+    // exceed `max_bytes`.
+    #[test]
+    fn payload_not_exceed_max_bytes() {
+        fn inner(seed: u64, max_bytes: u16) -> TestResult {
+            let max_bytes = max_bytes as usize;
+            let rng = SmallRng::seed_from_u64(seed);
+            let syslog = Syslog5424::default();
+
+            let mut bytes = Vec::with_capacity(max_bytes);
+            syslog.to_bytes(rng, max_bytes, &mut bytes).unwrap();
+            debug_assert!(
+                bytes.len() <= max_bytes,
+                "{:?}",
+                std::str::from_utf8(&bytes).unwrap()
+            );
+
+            TestResult::passed()
+        }
+        QuickCheck::new()
+            .tests(1_000)
+            .quickcheck(inner as fn(u64, u16) -> TestResult);
+    }
+}

--- a/lading_generators/src/tcp_gen/config.rs
+++ b/lading_generators/src/tcp_gen/config.rs
@@ -20,6 +20,8 @@ pub struct Config {
 pub enum Variant {
     /// Generates Fluent messages
     Fluent,
+    /// Generates syslog5424 messages
+    Syslog5424,
 }
 
 /// The [`Target`] instance from which to derive workers

--- a/lading_generators/src/tcp_gen/worker.rs
+++ b/lading_generators/src/tcp_gen/worker.rs
@@ -72,6 +72,9 @@ impl Worker {
             &BLOCK_BYTE_SIZES,
         );
         let block_cache = match target.variant {
+            Variant::Syslog5424 => {
+                construct_block_cache(&payload::Syslog5424::default(), &block_chunks, &labels)
+            }
             Variant::Fluent => {
                 construct_block_cache(&payload::Fluent::default(), &block_chunks, &labels)
             }


### PR DESCRIPTION
This PR gives lading the ability to generate Syslog5424 from tcp_gen. I have confirmed this is parsed by vector. 