### PR TITLE
Add basic Dockerfile and image release job

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target
+Dockerfile
+.dockerignore
+.git
+.gitignore

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - '*'
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
 jobs:
   publish:
     name: Publish for ${{ matrix.os }}
@@ -40,3 +44,29 @@ jobs:
           target/release/udp_blackhole
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-and-push-image:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to the Container registry
+        uses: docker/login-action@v1
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata for Docker
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM docker.io/library/rust:1.54.0 AS builder
+
+WORKDIR /app
+COPY . /app
+RUN cargo build --release --locked
+
+FROM gcr.io/distroless/cc AS runtime
+COPY --from=builder /app/target/release/file_gen /
+COPY --from=builder /app/target/release/http_gen /
+COPY --from=builder /app/target/release/kafka_gen /
+COPY --from=builder /app/target/release/tcp_gen /
+COPY --from=builder /app/target/release/http_blackhole /
+COPY --from=builder /app/target/release/udp_blackhole /


### PR DESCRIPTION
Signed-off-by: Spencer Gilbert <spencer.gilbert@gmail.com>

I think this release process should work, based off the gh docs and actions examples. I didn't see that any of the lading tools needed any system deps aside from libc things