### PR TITLE
Configure all lading programs through files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,7 +643,7 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "lading_blackholes"
-version = "0.4.8"
+version = "0.5.0"
 dependencies = [
  "argh",
  "hyper",
@@ -653,12 +653,13 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "tower",
 ]
 
 [[package]]
 name = "lading_common"
-version = "0.4.8"
+version = "0.5.0"
 dependencies = [
  "arbitrary",
  "bytecount",
@@ -674,7 +675,7 @@ dependencies = [
 
 [[package]]
 name = "lading_generators"
-version = "0.4.8"
+version = "0.5.0"
 dependencies = [
  "argh",
  "byte-unit",

--- a/lading_blackholes/Cargo.toml
+++ b/lading_blackholes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading_blackholes"
-version = "0.4.8"
+version = "0.5.0"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
 license = "MIT"
@@ -13,6 +13,7 @@ description = "Blackhole programs with some instrumentation"
 tower = { version = "0.4", default-features = false, features = ["timeout", "limit", "load-shed"] }
 metrics = { version = "0.17", default-features = false, features = ["std"] }
 metrics-exporter-prometheus = { version = "0.6", default-features = false, features = ["tokio-exporter"] }
+toml = "0.5"
 
 [dependencies.argh]
 version = "0.1"

--- a/lading_blackholes/src/bin/udp_blackhole.rs
+++ b/lading_blackholes/src/bin/udp_blackhole.rs
@@ -1,31 +1,52 @@
 use argh::FromArgs;
 use metrics::counter;
+use metrics_exporter_prometheus::PrometheusBuilder;
+use serde::Deserialize;
 use std::io;
+use std::io::Read;
 use std::net::SocketAddr;
 use tokio::net::UdpSocket;
 use tokio::runtime::Builder;
 
+fn default_config_path() -> String {
+    "/etc/lading/udp_blackhole.toml".to_string()
+}
+
 #[derive(FromArgs)]
 /// `udp_blackhole` options
 struct Opts {
+    /// path on disk to the configuration file
+    #[argh(option, default = "default_config_path()")]
+    config_path: String,
+}
+
+/// Main configuration struct for this program
+#[derive(Debug, Deserialize)]
+pub struct Config {
     /// number of worker threads to use in this program
-    #[argh(option)]
     pub worker_threads: u16,
     /// address -- IP plus port -- to bind to
-    #[argh(option)]
     pub binding_addr: SocketAddr,
+    /// Address and port for prometheus exporter
+    pub prometheus_addr: SocketAddr,
 }
 
 struct Server {
     addr: SocketAddr,
+    prom_addr: SocketAddr,
 }
 
 impl Server {
-    fn new(addr: SocketAddr) -> Self {
-        Self { addr }
+    fn new(addr: SocketAddr, prom_addr: SocketAddr) -> Self {
+        Self { addr, prom_addr }
     }
 
     async fn run(self) -> Result<(), io::Error> {
+        let _: () = PrometheusBuilder::new()
+            .listen_address(self.prom_addr)
+            .install()
+            .unwrap();
+
         let socket = UdpSocket::bind(&self.addr).await?;
         let mut buf: Vec<u8> = vec![0; 4096];
 
@@ -36,11 +57,22 @@ impl Server {
     }
 }
 
-fn main() {
+fn get_config() -> Config {
     let ops: Opts = argh::from_env();
-    let server = Server::new(ops.binding_addr);
+    let mut file: std::fs::File = std::fs::OpenOptions::new()
+        .read(true)
+        .open(ops.config_path)
+        .unwrap();
+    let mut contents = String::new();
+    file.read_to_string(&mut contents).unwrap();
+    toml::from_str(&contents).unwrap()
+}
+
+fn main() {
+    let config: Config = get_config();
+    let server = Server::new(config.binding_addr, config.prometheus_addr);
     let runtime = Builder::new_multi_thread()
-        .worker_threads(ops.worker_threads as usize)
+        .worker_threads(config.worker_threads as usize)
         .enable_io()
         .build()
         .unwrap();

--- a/lading_common/Cargo.toml
+++ b/lading_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading_common"
-version = "0.4.8"
+version = "0.5.0"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
 license = "MIT"

--- a/lading_generators/Cargo.toml
+++ b/lading_generators/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lading_generators"
 readme = "README.md"
-version = "0.4.8"
+version = "0.5.0"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
 license = "MIT"

--- a/lading_generators/src/bin/file_gen.rs
+++ b/lading_generators/src/bin/file_gen.rs
@@ -10,11 +10,15 @@ use std::net::SocketAddr;
 use std::{fs, mem};
 use tokio::runtime::Builder;
 
+fn default_config_path() -> String {
+    "/etc/lading/file_gen.toml".to_string()
+}
+
 #[derive(FromArgs)]
 /// `file_gen` options
 struct Opts {
     /// path on disk to the configuration file
-    #[argh(option)]
+    #[argh(option, default = "default_config_path()")]
     config_path: String,
 }
 

--- a/lading_generators/src/bin/http_gen.rs
+++ b/lading_generators/src/bin/http_gen.rs
@@ -8,11 +8,15 @@ use std::io::Read;
 use std::net::SocketAddr;
 use tokio::runtime::Builder;
 
+fn default_config_path() -> String {
+    "/etc/lading/http_gen.toml".to_string()
+}
+
 #[derive(FromArgs)]
 /// `http_gen` options
 struct Opts {
     /// path on disk to the configuration file
-    #[argh(option)]
+    #[argh(option, default = "default_config_path()")]
     config_path: String,
 }
 

--- a/lading_generators/src/bin/kafka_gen.rs
+++ b/lading_generators/src/bin/kafka_gen.rs
@@ -8,11 +8,15 @@ use std::io::Read;
 use std::net::SocketAddr;
 use tokio::runtime::Builder;
 
+fn default_config_path() -> String {
+    "/etc/lading/kafka_gen.toml".to_string()
+}
+
 #[derive(FromArgs)]
 /// `kafka_gen` options
 struct Opts {
     /// path on disk to the configuration file
-    #[argh(option)]
+    #[argh(option, default = "default_config_path()")]
     config_path: String,
 }
 

--- a/lading_generators/src/bin/tcp_gen.rs
+++ b/lading_generators/src/bin/tcp_gen.rs
@@ -8,11 +8,15 @@ use std::io::Read;
 use std::net::SocketAddr;
 use tokio::runtime::Builder;
 
+fn default_config_path() -> String {
+    "/etc/lading/tcp_gen.toml".to_string()
+}
+
 #[derive(FromArgs)]
 /// `tcp_gen` options
 struct Opts {
     /// path on disk to the configuration file
-    #[argh(option)]
+    #[argh(option, default = "default_config_path()")]
     config_path: String,
 }
 


### PR DESCRIPTION
Previously we allowed for some lading programs to be configured through
command-line flags. This makes lading challenging to use in contexts where
file-based configuration is more convenient, so we now have every lading binary
read a config file from under `/etc/lading`.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>