### PR TITLE
Add Splunk HEC blackhole

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,10 @@ jobs:
           target/release/http_gen
           target/release/kafka_gen
           target/release/tcp_gen
+          target/release/splunk_hec_gen
           target/release/http_blackhole
           target/release/udp_blackhole
+          target/release/splunk_hec_blackhole
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,7 +635,7 @@ dependencies = [
 
 [[package]]
 name = "lading_blackholes"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "argh",
  "hyper",
@@ -651,7 +651,7 @@ dependencies = [
 
 [[package]]
 name = "lading_common"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "arbitrary",
  "bytecount",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "lading_generators"
-version = "0.5.2"
+version = "0.5.3"
 dependencies = [
  "argh",
  "byte-unit",

--- a/lading_blackholes/Cargo.toml
+++ b/lading_blackholes/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading_blackholes"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
 license = "MIT"

--- a/lading_blackholes/src/bin/splunk_hec_blackhole.rs
+++ b/lading_blackholes/src/bin/splunk_hec_blackhole.rs
@@ -91,7 +91,6 @@ struct HecResponse {
     ack_id: u64,
 }
 
-#[allow(clippy::borrow_interior_mutable_const)]
 async fn srv(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
     metrics::counter!("requests_received", 1);
 

--- a/lading_blackholes/src/bin/splunk_hec_blackhole.rs
+++ b/lading_blackholes/src/bin/splunk_hec_blackhole.rs
@@ -1,0 +1,186 @@
+use std::{collections::HashMap, fs::read_to_string, net::SocketAddr, sync::atomic::{AtomicU64, Ordering}, time::Duration};
+
+use argh::FromArgs;
+use hyper::{
+    body, header,
+    server::conn::{AddrIncoming, AddrStream},
+    service::{make_service_fn, service_fn},
+    Body, Method, Request, Response, Server, StatusCode,
+};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use once_cell::sync::OnceCell;
+use serde::{Deserialize, Serialize};
+use tokio::runtime::Builder;
+use tower::ServiceBuilder;
+
+const RESPONSE: OnceCell<Vec<u8>> = OnceCell::new();
+static ACK_ID: AtomicU64 = AtomicU64::new(0);
+
+fn default_concurrent_requests_max() -> usize {
+    100
+}
+
+fn default_config_path() -> String {
+    "/etc/lading/splunk_hec_blackhole.toml".to_string()
+}
+
+#[derive(FromArgs)]
+/// `splunk_hec_blackhole` options
+struct Opts {
+    /// path on disk to the configuration file
+    #[argh(option, default = "default_config_path()")]
+    config_path: String,
+}
+
+#[derive(Debug, Deserialize)]
+/// Main configuration struct for this program
+struct Config {
+    /// number of worker threads to use in this program
+    pub worker_threads: u16,
+    /// number of concurrent HTTP connections to allow
+    #[serde(default = "default_concurrent_requests_max")]
+    pub concurrent_requests_max: usize,
+    /// address -- IP plus port -- to bind to
+    pub binding_addr: SocketAddr,
+    /// address -- IP plus port -- for prometheus exporting to bind to
+    pub prometheus_addr: SocketAddr,
+}
+
+fn get_config() -> Config {
+    let opts = argh::from_env::<Opts>();
+    let contents = read_to_string(&opts.config_path).unwrap();
+    toml::from_str::<Config>(&contents).unwrap()
+}
+
+struct SplunkHecServer {
+    prometheus_addr: SocketAddr,
+    httpd_addr: SocketAddr,
+}
+
+#[derive(Deserialize)]
+struct HecAckRequest {
+    acks: Vec<u64>,
+}
+
+#[derive(Serialize)]
+struct HecAckResponse {
+    acks: HashMap<u64, bool>,
+}
+
+impl From<HecAckRequest> for HecAckResponse {
+    fn from(ack_request: HecAckRequest) -> Self {
+        let acks = ack_request.acks.into_iter().map(|ack_id| (ack_id, true)).collect();
+        HecAckResponse { acks }
+    }
+}
+
+#[derive(Serialize)]
+struct HecResponse {
+    text: &'static str,
+    // https://docs.splunk.com/Documentation/Splunk/8.2.3/Data/TroubleshootHTTPEventCollector#Possible_error_codes
+    code: u8,
+    #[serde(rename = "ackId")]
+    ack_id: u64,
+}
+
+#[allow(clippy::borrow_interior_mutable_const)]
+async fn srv(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    metrics::counter!("requests_received", 1);
+
+    let (parts, body) = req.into_parts();
+    let bytes = body::to_bytes(body).await?;
+    metrics::counter!("bytes_received", bytes.len() as u64);
+
+    let mut okay = Response::default();
+    *okay.status_mut() = StatusCode::OK;
+    okay.headers_mut().insert(
+        header::CONTENT_TYPE,
+        header::HeaderValue::from_static("application/json"),
+    );
+
+    match (parts.method, parts.uri.path()) {
+        (Method::POST, "/services/collector/ack") => {
+            match serde_json::from_slice::<HecAckRequest>(&bytes) {
+                Ok(ack_request) => {
+                    let body_bytes = serde_json::to_vec(&HecAckResponse::from(ack_request)).unwrap();
+                    *okay.body_mut() = Body::from(body_bytes);
+                },
+                Err(_) => {
+                    *okay.status_mut() = StatusCode::BAD_REQUEST;
+                    let body_bytes = RESPONSE.get_or_init(|| vec![]).clone();
+                    *okay.body_mut() = Body::from(body_bytes);
+                }
+            }
+        }
+        (
+            Method::POST,
+            "/services/collector/event"
+            | "/services/collector/event/1.0"
+            | "/services/collector/raw"
+            | "/services/collector/raw/1.0",
+        ) => {
+            let ack_id = ACK_ID.fetch_add(1, Ordering::Relaxed);
+            let body_bytes = serde_json::to_vec(&HecResponse {
+                text: "Success",
+                code: 0,
+                ack_id,
+            }).unwrap();
+            *okay.body_mut() = Body::from(body_bytes);
+        }
+        _ => {
+            let body_bytes = RESPONSE.get_or_init(|| vec![]).clone();
+            *okay.body_mut() = Body::from(body_bytes);
+        }
+    }
+
+    Ok(okay)
+}
+
+impl SplunkHecServer {
+    fn new(httpd_addr: SocketAddr, prometheus_addr: SocketAddr) -> Self {
+        Self {
+            prometheus_addr,
+            httpd_addr,
+        }
+    }
+
+    async fn run(self, concurrency_limit: usize) -> Result<(), hyper::Error> {
+        let _: () = PrometheusBuilder::new()
+            .listen_address(self.prometheus_addr)
+            .install()
+            .unwrap();
+
+        let service = make_service_fn(|_: &AddrStream| async move {
+            Ok::<_, hyper::Error>(service_fn(move |request| srv(request)))
+        });
+        let svc = ServiceBuilder::new()
+            .load_shed()
+            .concurrency_limit(concurrency_limit)
+            .timeout(Duration::from_secs(1))
+            .service(service);
+
+        let addr = AddrIncoming::bind(&self.httpd_addr)
+            .map(|mut addr| {
+                addr.set_keepalive(Some(Duration::from_secs(60)));
+                addr
+            })
+            .unwrap();
+        let server = Server::builder(addr).serve(svc);
+        server.await?;
+        Ok(())
+    }
+}
+
+fn main() {
+    let config: Config = get_config();
+    let splunk_server = SplunkHecServer::new(config.binding_addr, config.prometheus_addr);
+    let runtime = Builder::new_multi_thread()
+        .worker_threads(config.worker_threads as usize)
+        .enable_io()
+        .enable_time()
+        .build()
+        .unwrap();
+    runtime
+        .block_on(splunk_server.run(config.concurrent_requests_max))
+        .unwrap();
+}

--- a/lading_common/Cargo.toml
+++ b/lading_common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lading_common"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
 license = "MIT"

--- a/lading_generators/Cargo.toml
+++ b/lading_generators/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lading_generators"
 readme = "README.md"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["Brian L. Troutwine <brian@troutwine.us>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
This PR adds a simple Splunk HEC blackhole that handles the following Splunk HEC paths
- POST `/services/collector/event | /services/collector/event/1.0 | /services/collector/raw | /services/collector/raw/1.0`
```jsonc
// Example response
{
  text: "Success",
  code: 0,
  ackId: 0,
}
```
`ackId` is a global `AtomicU64` that increments after each request, wrapping to 0 if needed. For simplicity, there is no notion of Splunk channels in this blackhole, but clients using channels can still successfully interact with this server. There is no Splunk HEC protocol guarantee that each channel receives `ackId`'s starting from `0`. 
- POST `/services/collector/ack`
```jsonc
// Example response
{
  acks: {
    0: true,
    1: true,
  }
}
```
For any ack query, we map over the provided `ackId`'s and return true.

- Requests to any other path result in a 200 OK with no body.