### PR TITLE
Allow http_gen to use static file payloads

### DIFF
--- a/lading_generators/src/http_gen/worker.rs
+++ b/lading_generators/src/http_gen/worker.rs
@@ -133,7 +133,11 @@ impl Worker {
                         &block_chunks,
                         &labels,
                     ),
-                    Variant::Static { .. } => unimplemented!(),
+                    Variant::Static { static_path } => construct_block_cache(
+                        &payload::Static::new(&static_path),
+                        &block_chunks,
+                        &labels,
+                    ),
                 };
 
                 Ok(Self {
@@ -217,6 +221,6 @@ impl Worker {
                 }
             })
             .await;
-        unimplemented!()
+        unreachable!()
     }
 }


### PR DESCRIPTION
This commit grants http_gen the ability to use it's static config option,
previously available but in a crash-your-program way.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>