### PR TITLE
Add Static Variant to tcp_gen

### DIFF
--- a/lading_generators/src/tcp_gen/config.rs
+++ b/lading_generators/src/tcp_gen/config.rs
@@ -2,7 +2,7 @@
 //! convenience mechanism for the rest of the program. Crashes are most likely
 //! to originate from this code, intentionally.
 use serde::Deserialize;
-use std::{collections::HashMap, net::SocketAddr};
+use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
 
 /// Main configuration struct for this program
 #[derive(Debug, Deserialize)]
@@ -23,6 +23,12 @@ pub enum Variant {
     Fluent,
     /// Generates syslog5424 messages
     Syslog5424,
+    /// Generates a static, user supplied data
+    Static {
+        /// Defines the file path to read static variant data from. Content is
+        /// assumed to be line-oriented but no other claim is made on the file.
+        static_path: PathBuf,
+    },
 }
 
 /// The [`Target`] instance from which to derive workers

--- a/lading_generators/src/tcp_gen/worker.rs
+++ b/lading_generators/src/tcp_gen/worker.rs
@@ -82,6 +82,9 @@ impl Worker {
             Variant::Fluent => {
                 construct_block_cache(&payload::Fluent::default(), &block_chunks, &labels)
             }
+            Variant::Static { ref static_path } => {
+                construct_block_cache(&payload::Static::new(&static_path), &block_chunks, &labels)
+            }
         };
 
         let addr = target


### PR DESCRIPTION
This adds the Static variant to tcp_gen.

I'm not sure if it is fully working as I can't seem to work out how to run it.

With this config file:

```yaml
worker_threads: 2
prometheus_addr: "0.0.0.0:9090"

targets:
  vector:
    addr: "localhost:8282"
    variant: "syslog5424"
    bytes_per_second: "500 Mb"
    block_sizes: ["1Kb", "2Kb", "4Kb", "8Kb", "256Kb", "512Kb", "1024Kb"]
    maximum_prebuild_cache_size_bytes: "1 Gb"
```

I get:

```
╰─$ cargo run --bin tcp_gen -- --config-path ./tcp_gen.yaml                                                                                  101 ↵
    Finished dev [unoptimized + debuginfo] target(s) in 0.07s
     Running `target/debug/tcp_gen --config-path ./tcp_gen.yaml`
thread 'main' panicked at 'Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.', /home/plertrood/.cargo/registry/src/github.com-1ecc6299db9ec823/tokio-1.14.0/src/runtime/blocking/shutdown.rs:51:21
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

No data gets sent to 8282.

Any ideas?


Signed-off-by: Stephen Wakely <fungus.humungus@gmail.com>