### PR TITLE
Make tcp_gen less crash prone around write errors

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.57.0"
+profile = "default"


### PR DESCRIPTION
This commit makes tcp_gen mirror http_gen with regard to write errors. The panic
on failed write approach makes sense when we're in a test rig, less when the
program is supposed to be generally useful.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>