### PR TITLE
Allocate buffer large enough to hold a UDP packet of maximum size

### DIFF
--- a/lading_blackholes/src/bin/udp_blackhole.rs
+++ b/lading_blackholes/src/bin/udp_blackhole.rs
@@ -48,7 +48,7 @@ impl Server {
             .unwrap();
 
         let socket = UdpSocket::bind(&self.addr).await?;
-        let mut buf: Vec<u8> = vec![0; 4096];
+        let mut buf: Vec<u8> = vec![0; 65536];
 
         loop {
             counter!("packet_received", 1);


### PR DESCRIPTION
I thought it would make sense to either be deliberate about dropping the contents entirely (buffer size of `0`) or allocate enough to fit a UDP packet of max size.