### PR TITLE
Convert from quickcheck to proptest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,13 +231,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
+name = "fastrand"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
- "log",
- "regex",
+ "instant",
 ]
 
 [[package]]
@@ -517,7 +531,7 @@ dependencies = [
  "metrics-util",
  "nix",
  "once_cell",
- "quickcheck",
+ "proptest",
  "rand",
  "rdkafka",
  "rmp-serde",
@@ -945,6 +959,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
 name = "quanta"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,15 +995,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "quickcheck"
-version = "1.0.3"
+name = "quick-error"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
-dependencies = [
- "env_logger",
- "log",
- "rand",
-]
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quote"
@@ -1018,6 +1053,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -1073,8 +1117,6 @@ version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -1092,6 +1134,15 @@ name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "rmp"
@@ -1112,6 +1163,18 @@ dependencies = [
  "byteorder",
  "rmp",
  "serde",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -1262,6 +1325,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "libc",
+ "redox_syscall",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -1505,6 +1582,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid =  { version = "0.8", features = ["serde", "v4"] }
 
 [dev-dependencies]
-quickcheck = "1"
+proptest = "1.0"
 
 [[bin]]
 name = "lading"

--- a/proptest-regressions/block.txt
+++ b/proptest-regressions/block.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 5d4e7b2574547350cad0dd0039ab9042fa1493f2e92e69e5d12d64cdf71d573e # shrinks to seed = 0, total_bytes = 0, block_bytes_sizes = []

--- a/proptest-regressions/payload/ascii.txt
+++ b/proptest-regressions/payload/ascii.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc b0a5e4db7ec2c4733f43f726a8960b63cd99d8d80e62aa5632b059f7a72106ce # shrinks to seed = 15194034853109340835, max_bytes = 0
+cc e2bc9dd7b2802fb4395c3e3efa1158afc6a1a58b769a0a484d71b8d3e2d25c9b # shrinks to seed = 15044724196553407659, max_bytes = 1

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,3 +5,5 @@ newline_style = "unix"
 # Nightly only features
 # unstable_features = true
 # imports_granularity = "crate"
+# group_imports = "StdExternalCrate"
+# wrap_comments = true

--- a/src/bin/lading.rs
+++ b/src/bin/lading.rs
@@ -1,3 +1,11 @@
+use std::{
+    collections::HashMap,
+    fmt::{self, Display},
+    io::Read,
+    path::PathBuf,
+    str::FromStr,
+};
+
 use clap::Parser;
 use lading::{
     blackhole,
@@ -8,11 +16,6 @@ use lading::{
     target::{self, Behavior, Output},
 };
 use metrics_exporter_prometheus::PrometheusBuilder;
-use std::{collections::HashMap, io::Read, path::PathBuf};
-use std::{
-    fmt::{self, Display},
-    str::FromStr,
-};
 use tokio::{
     runtime::Builder,
     signal,
@@ -67,7 +70,8 @@ struct Opts {
     /// additional labels to apply to all captures, format KEY=VAL,KEY2=VAL
     #[clap(long)]
     global_labels: Option<CliKeyValues>,
-    /// additional environment variables to apply to the target, format KEY=VAL,KEY2=VAL
+    /// additional environment variables to apply to the target, format
+    /// KEY=VAL,KEY2=VAL
     #[clap(long)]
     target_environment_variables: Option<CliKeyValues>,
     /// the path of the target executable
@@ -94,7 +98,8 @@ struct Opts {
     /// the time, in seconds, to run the target and collect samples about it
     #[clap(long, default_value_t = 120)]
     experiment_duration_seconds: u32,
-    /// the time, in seconds, to allow the target to run without collecting samples
+    /// the time, in seconds, to allow the target to run without collecting
+    /// samples
     #[clap(long, default_value_t = 30)]
     warmup_duration_seconds: u32,
 }

--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -1,5 +1,6 @@
-use crate::signals::Shutdown;
 use serde::Deserialize;
+
+use crate::signals::Shutdown;
 
 pub mod http;
 pub mod splunk_hec;
@@ -7,6 +8,7 @@ pub mod sqs;
 pub mod tcp;
 pub mod udp;
 
+#[derive(Debug)]
 pub enum Error {
     Tcp(tcp::Error),
     Http(http::Error),
@@ -15,7 +17,7 @@ pub enum Error {
     Sqs(sqs::Error),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum Config {
     Tcp(tcp::Config),
@@ -25,6 +27,7 @@ pub enum Config {
     Sqs(sqs::Config),
 }
 
+#[derive(Debug)]
 pub enum Server {
     Tcp(tcp::Tcp),
     Http(http::Http),
@@ -61,7 +64,8 @@ impl Server {
     ///
     /// # Errors
     ///
-    /// Function will return an error if the underlying sub-server signals error.
+    /// Function will return an error if the underlying sub-server signals
+    /// error.
     pub async fn run(self) -> Result<(), Error> {
         match self {
             Server::Tcp(inner) => inner.run().await.map_err(Error::Tcp),

--- a/src/blackhole/http.rs
+++ b/src/blackhole/http.rs
@@ -1,3 +1,5 @@
+use std::{net::SocketAddr, str::FromStr, time::Duration};
+
 use hyper::{
     body, header,
     server::conn::{AddrIncoming, AddrStream},
@@ -6,7 +8,6 @@ use hyper::{
 };
 use once_cell::unsync::OnceCell;
 use serde::{Deserialize, Serialize};
-use std::{net::SocketAddr, str::FromStr, time::Duration};
 use tower::ServiceBuilder;
 use tracing::{error, info};
 
@@ -19,6 +20,7 @@ fn default_concurrent_requests_max() -> usize {
     100
 }
 
+#[derive(Debug)]
 pub enum Error {
     Hyper(hyper::Error),
 }
@@ -44,7 +46,7 @@ fn default_body_variant() -> BodyVariant {
     BodyVariant::AwsKinesis
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Copy)]
 /// Main configuration struct for this program
 pub struct Config {
     /// number of concurrent HTTP connections to allow
@@ -119,6 +121,7 @@ async fn srv(
     }
 }
 
+#[derive(Debug)]
 pub struct Http {
     httpd_addr: SocketAddr,
     body_variant: BodyVariant,

--- a/src/blackhole/splunk_hec.rs
+++ b/src/blackhole/splunk_hec.rs
@@ -1,3 +1,10 @@
+use std::{
+    collections::HashMap,
+    net::SocketAddr,
+    sync::atomic::{AtomicU64, Ordering},
+    time::Duration,
+};
+
 use hyper::{
     body, header,
     server::conn::{AddrIncoming, AddrStream},
@@ -5,12 +12,6 @@ use hyper::{
     Body, Method, Request, Response, Server, StatusCode,
 };
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashMap,
-    net::SocketAddr,
-    sync::atomic::{AtomicU64, Ordering},
-    time::Duration,
-};
 use tower::ServiceBuilder;
 use tracing::{error, info};
 
@@ -22,11 +23,12 @@ fn default_concurrent_requests_max() -> usize {
     100
 }
 
+#[derive(Debug)]
 pub enum Error {
     Hyper(hyper::Error),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Copy)]
 /// Main configuration struct for this program
 pub struct Config {
     /// number of concurrent HTTP connections to allow
@@ -123,6 +125,7 @@ async fn srv(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
     }
 }
 
+#[derive(Debug)]
 pub struct SplunkHec {
     concurrency_limit: usize,
     httpd_addr: SocketAddr,

--- a/src/blackhole/sqs.rs
+++ b/src/blackhole/sqs.rs
@@ -1,4 +1,5 @@
-use crate::signals::Shutdown;
+use std::net::SocketAddr;
+
 use hyper::{
     body,
     server::conn::{AddrIncoming, AddrStream},
@@ -7,11 +8,13 @@ use hyper::{
 };
 use rand::{distributions::Alphanumeric, thread_rng, Rng};
 use serde::Deserialize;
-use std::net::SocketAddr;
 use tokio::time::Duration;
 use tower::ServiceBuilder;
 use tracing::{error, info};
 
+use crate::signals::Shutdown;
+
+#[derive(Debug)]
 pub enum Error {
     Hyper(hyper::Error),
 }
@@ -20,7 +23,7 @@ fn default_concurrent_requests_max() -> usize {
     100
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Copy)]
 /// Main configuration struct for this program
 pub struct Config {
     /// number of concurrent HTTP connections to allow
@@ -30,6 +33,7 @@ pub struct Config {
     pub binding_addr: SocketAddr,
 }
 
+#[derive(Debug)]
 pub struct Sqs {
     httpd_addr: SocketAddr,
     concurrency_limit: usize,

--- a/src/blackhole/tcp.rs
+++ b/src/blackhole/tcp.rs
@@ -1,17 +1,20 @@
-use crate::signals::Shutdown;
+use std::{io, net::SocketAddr};
+
 use futures::stream::StreamExt;
 use metrics::counter;
 use serde::Deserialize;
-use std::{io, net::SocketAddr};
 use tokio::net::{TcpListener, TcpStream};
 use tokio_util::io::ReaderStream;
 use tracing::info;
 
+use crate::signals::Shutdown;
+
+#[derive(Debug)]
 pub enum Error {
     Io(io::Error),
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Copy)]
 pub struct Config {
     /// address -- IP plus port -- to bind to
     binding_addr: SocketAddr,

--- a/src/blackhole/udp.rs
+++ b/src/blackhole/udp.rs
@@ -1,22 +1,25 @@
+use std::{io, net::SocketAddr};
+
 use metrics::counter;
 use serde::Deserialize;
-use std::{io, net::SocketAddr};
 use tokio::net::UdpSocket;
 use tracing::info;
 
 use crate::signals::Shutdown;
 
+#[derive(Debug)]
 pub enum Error {
     Io(io::Error),
 }
 
 /// Main configuration struct for this program
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Clone, Copy)]
 pub struct Config {
     /// address -- IP plus port -- to bind to
     pub binding_addr: SocketAddr,
 }
 
+#[derive(Debug)]
 pub struct Udp {
     binding_addr: SocketAddr,
     shutdown: Shutdown,

--- a/src/block.rs
+++ b/src/block.rs
@@ -1,30 +1,42 @@
-use crate::payload::{self, Serialize};
+use std::{
+    convert::TryInto,
+    num::{NonZeroU32, NonZeroUsize},
+};
+
 use metrics::gauge;
 use rand::{prelude::SliceRandom, Rng};
-use std::{convert::TryInto, num::NonZeroU32};
 
-#[derive(Debug)]
+use crate::payload::Serialize;
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Error {
-    Payload(payload::Error),
-    Empty,
+    Chunk(ChunkError),
 }
 
-impl From<payload::Error> for Error {
-    fn from(error: payload::Error) -> Self {
-        Error::Payload(error)
+impl From<ChunkError> for Error {
+    fn from(error: ChunkError) -> Self {
+        Error::Chunk(error)
     }
 }
 
 #[derive(Debug)]
-pub struct Block {
-    pub total_bytes: NonZeroU32,
-    pub lines: u64,
-    pub bytes: Vec<u8>,
+pub(crate) struct Block {
+    pub(crate) total_bytes: NonZeroU32,
+    pub(crate) lines: u64,
+    pub(crate) bytes: Vec<u8>,
 }
 
 #[inline]
 fn total_newlines(input: &[u8]) -> u64 {
     bytecount::count(input, b'\n') as u64
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum ChunkError {
+    /// The slice of byte sizes given to [`chunk_bytes`] was empty.
+    EmptyBlockBytes,
+    /// The `total_bytes` parameter is insufficient.
+    InsufficientTotalBytes,
 }
 
 /// Construct a vec of block sizes that fit into `total_bytes`.
@@ -41,30 +53,46 @@ fn total_newlines(input: &[u8]) -> u64 {
 /// size. It's possible that a user could supply just the right parameters to
 /// make this loop infinitely. A more clever algorithm would be great.
 ///
+/// # Errors
+///
+/// Function will return an error if `block_byte_sizes` is empty or if a member
+/// of `block_byte_sizes` is large than `total_bytes`.
+///
 /// # Panics
 ///
 /// Function will panic if `block_bytes_sizes` is empty.
-pub fn chunk_bytes<R>(rng: &mut R, total_bytes: usize, block_byte_sizes: &[usize]) -> Vec<usize>
+pub(crate) fn chunk_bytes<R>(
+    rng: &mut R,
+    total_bytes: NonZeroUsize,
+    block_byte_sizes: &[NonZeroUsize],
+) -> Result<Vec<usize>, Error>
 where
     R: Rng + Sized,
 {
-    assert!(!block_byte_sizes.is_empty());
+    if block_byte_sizes.is_empty() {
+        return Err(ChunkError::EmptyBlockBytes.into());
+    }
+    for bb in block_byte_sizes {
+        if *bb > total_bytes {
+            return Err(ChunkError::InsufficientTotalBytes.into());
+        }
+    }
 
     let mut chunks = Vec::new();
-    let mut bytes_remaining = total_bytes;
-    let minimum = *block_byte_sizes.iter().min().unwrap();
-    let maximum = *block_byte_sizes.iter().max().unwrap();
+    let mut bytes_remaining = total_bytes.get();
+    let minimum = block_byte_sizes.iter().min().unwrap().get();
+    let maximum = block_byte_sizes.iter().max().unwrap().get();
 
     while bytes_remaining > minimum {
         let bytes_max = std::cmp::min(maximum, bytes_remaining);
-        let block_bytes = block_byte_sizes.choose(rng).unwrap();
-        if *block_bytes > bytes_max {
+        let block_bytes = block_byte_sizes.choose(rng).unwrap().get();
+        if block_bytes > bytes_max {
             continue;
         }
-        chunks.push(*block_bytes);
-        bytes_remaining = bytes_remaining.saturating_sub(*block_bytes);
+        chunks.push(block_bytes);
+        bytes_remaining = bytes_remaining.saturating_sub(block_bytes);
     }
-    chunks
+    Ok(chunks)
 }
 
 #[allow(clippy::ptr_arg)]
@@ -81,7 +109,7 @@ where
 ///
 /// Function will panic if the `serializer` signals an error. In the futures we
 /// would like to propagate this error to the caller.
-pub fn construct_block_cache<R, S>(
+pub(crate) fn construct_block_cache<R, S>(
     mut rng: R,
     serializer: &S,
     block_chunks: &[usize],
@@ -98,10 +126,14 @@ where
             .to_bytes(&mut rng, *block_size, &mut block)
             .unwrap();
         block.shrink_to_fit();
-        // For unknown reasons this fails. Will need to start property testing
-        // this library.
-        // assert!(!block.is_empty());
         if block.is_empty() {
+            // Blocks may be empty, especially when the amount of bytes
+            // requested for the block are relatively low. This is a quirk of
+            // our use of Arbitrary. We do not have the ability to tell that
+            // library that we would like such and such number of bytes
+            // approximately from an instance. This does mean that we sometimes
+            // waste computation because the size of the block given cannot be
+            // serialized into.
             continue;
         }
         let total_bytes = NonZeroU32::new(block.len().try_into().unwrap()).unwrap();
@@ -115,4 +147,61 @@ where
     assert!(!block_cache.is_empty());
     gauge!("block_construction_complete", 1.0, labels);
     block_cache
+}
+
+#[cfg(test)]
+mod test {
+    use std::num::NonZeroUsize;
+
+    use proptest::{collection, prelude::*};
+    use rand::{rngs::SmallRng, SeedableRng};
+
+    use crate::block::{chunk_bytes, ChunkError, Error};
+
+    /// Construct our block_bytes_sizes vector and the total_bytes value. We are
+    /// careful to never generate an empty vector nor a total_bytes that is less
+    /// than any value in block_bytes_sizes.
+    fn total_bytes_and_block_bytes() -> impl Strategy<Value = (NonZeroUsize, Vec<NonZeroUsize>)> {
+        (1..usize::MAX).prop_flat_map(|total_bytes| {
+            (
+                Just(NonZeroUsize::new(total_bytes).unwrap()),
+                collection::vec(
+                    (1..total_bytes).prop_map(|i| NonZeroUsize::new(i).unwrap()),
+                    1..1_000,
+                ),
+            )
+        })
+    }
+
+    // No chunk is a returned set of chunks should ever be 0.
+    proptest! {
+        #[test]
+        fn chunk_never_size_zero(seed: u64, (total_bytes, block_bytes_sizes) in total_bytes_and_block_bytes()) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let chunks = chunk_bytes(&mut rng, total_bytes, &block_bytes_sizes).unwrap();
+
+            for chunk in chunks {
+                prop_assert!(chunk > 0);
+            }
+        }
+    }
+
+    // The vec of chunks must not be empty.
+    proptest! {
+        #[test]
+        fn chunks_never_empty(seed: u64, (total_bytes, block_bytes_sizes) in total_bytes_and_block_bytes()) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            let chunks = chunk_bytes(&mut rng, total_bytes, &block_bytes_sizes).unwrap();
+            prop_assert!(!chunks.is_empty())
+        }
+    }
+
+    // Passing an empty block_byte_sizes always triggers an error condition.
+    proptest! {
+        #[test]
+        fn chunks_empty_trigger_error(seed: u64, total_bytes in (1..usize::MAX).prop_map(|i| NonZeroUsize::new(i).unwrap())) {
+            let mut rng = SmallRng::seed_from_u64(seed);
+            prop_assert_eq!(Err(Error::Chunk(ChunkError::EmptyBlockBytes)), chunk_bytes(&mut rng, total_bytes, &[]));
+        }
+    }
 }

--- a/src/captures.rs
+++ b/src/captures.rs
@@ -1,6 +1,3 @@
-use crate::signals::Shutdown;
-use metrics_util::registry::{AtomicStorage, Registry};
-use serde::Serialize;
 use std::{
     borrow::Cow,
     collections::HashMap,
@@ -10,6 +7,9 @@ use std::{
     sync::{atomic::Ordering, Arc},
     time::{SystemTime, UNIX_EPOCH},
 };
+
+use metrics_util::registry::{AtomicStorage, Registry};
+use serde::Serialize;
 use tokio::{
     fs::File,
     io::{AsyncWriteExt, BufWriter},
@@ -17,6 +17,8 @@ use tokio::{
 };
 use tracing::{debug, info};
 use uuid::Uuid;
+
+use crate::signals::Shutdown;
 
 #[derive(Debug, Serialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
@@ -44,6 +46,7 @@ struct Inner {
     registry: Registry<metrics::Key, AtomicStorage>,
 }
 
+#[allow(missing_debug_implementations)]
 pub struct CaptureManager {
     fetch_index: u64,
     run_id: Uuid,

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -1,12 +1,14 @@
+use std::io::Read;
+
 use bytes::{Buf, Bytes};
 use flate2::read::{MultiGzDecoder, ZlibDecoder};
 use hyper::{Body, StatusCode};
-use std::io::Read;
 
-/// decode decodes a HTTP request body based on its Content-Encoding header. Only identity, gzip, and
-/// deflate are currently supported content encodings.
+/// decode decodes a HTTP request body based on its Content-Encoding header.
+/// Only identity, gzip, and deflate are currently supported content encodings.
 ///
-/// It supports multiple content encodings joined by ,s. They are decoded in the order provided.
+/// It supports multiple content encodings joined by ,s. They are decoded in the
+/// order provided.
 ///
 /// See [RFC7231](https://httpwg.org/specs/rfc7231.html#header.content-encoding) for more details
 /// on this header value.
@@ -19,7 +21,7 @@ use std::io::Read;
 /// * The body cannot be decoded as the specified content type
 ///
 /// This response body can be passed back as the HTTP response to the client
-pub fn decode(
+pub(crate) fn decode(
     content_encoding: Option<&hyper::header::HeaderValue>,
     mut body: Bytes,
 ) -> Result<Bytes, hyper::Response<hyper::Body>> {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,7 +1,4 @@
-use std::path::PathBuf;
-use std::process::Stdio;
-use std::str;
-use std::{fmt, fs};
+use std::{fmt, fs, path::PathBuf, process::Stdio, str};
 
 use serde::Deserialize;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,8 +1,9 @@
 //! This module controls configuration parsing from the end user, providing a
 //! convenience mechanism for the rest of the program. Crashes are most likely
 //! to originate from this code, intentionally.
-use serde::Deserialize;
 use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
+
+use serde::Deserialize;
 
 use crate::{blackhole, generator, inspector, target};
 

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,5 +1,6 @@
-use crate::signals::Shutdown;
 use serde::Deserialize;
+
+use crate::signals::Shutdown;
 
 pub mod file_gen;
 pub mod http;
@@ -26,6 +27,7 @@ pub enum Config {
     FileGen(file_gen::Config),
 }
 
+#[derive(Debug)]
 pub enum Server {
     Tcp(tcp::Tcp),
     Http(http::Http),
@@ -68,7 +70,8 @@ impl Server {
     ///
     /// # Errors
     ///
-    /// Function will return an error if the underlying sub-server signals error.
+    /// Function will return an error if the underlying sub-server signals
+    /// error.
     pub async fn run(self) -> Result<(), Error> {
         match self {
             Server::Tcp(inner) => inner.spin().await.map_err(Error::Tcp),

--- a/src/inspector.rs
+++ b/src/inspector.rs
@@ -34,6 +34,7 @@ pub struct Config {
     pub output: Output,
 }
 
+#[derive(Debug)]
 pub struct Server {
     config: Config,
     shutdown: Shutdown,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,24 @@
 #![deny(clippy::all)]
 #![deny(clippy::cargo)]
 #![deny(clippy::pedantic)]
+#![deny(unused_extern_crates)]
+#![deny(unused_allocation)]
+#![deny(unused_assignments)]
+#![deny(unused_comparisons)]
+#![deny(unreachable_pub)]
+#![deny(missing_copy_implementations)]
+#![deny(missing_debug_implementations)]
 #![allow(clippy::cast_precision_loss)]
 #![allow(clippy::multiple_crate_versions)]
 
 pub mod blackhole;
-pub mod block;
+pub(crate) mod block;
 pub mod captures;
-pub mod codec;
+pub(crate) mod codec;
 mod common;
 pub mod config;
 pub mod generator;
 pub mod inspector;
-pub mod payload;
+pub(crate) mod payload;
 pub mod signals;
 pub mod target;

--- a/src/payload.rs
+++ b/src/payload.rs
@@ -1,13 +1,14 @@
-pub use ascii::Ascii;
-pub use datadog_logs::DatadogLog;
-pub use fluent::Fluent;
-pub use foundationdb::FoundationDb;
-pub use json::Json;
-use rand::Rng;
-pub use splunk_hec::{Encoding as SplunkHecEncoding, SplunkHec};
-pub use statik::Static;
 use std::io::{self, Write};
-pub use syslog::Syslog5424;
+
+pub(crate) use ascii::Ascii;
+pub(crate) use datadog_logs::DatadogLog;
+pub(crate) use fluent::Fluent;
+pub(crate) use foundationdb::FoundationDb;
+pub(crate) use json::Json;
+use rand::Rng;
+pub(crate) use splunk_hec::{Encoding as SplunkHecEncoding, SplunkHec};
+pub(crate) use statik::Static;
+pub(crate) use syslog::Syslog5424;
 
 mod ascii;
 mod common;
@@ -21,7 +22,7 @@ mod syslog;
 
 /// Errors related to serialization
 #[derive(Debug)]
-pub enum Error {
+pub(crate) enum Error {
     /// MsgPack payload could not be encoded
     MsgPack(rmp_serde::encode::Error),
     /// Json payload could not be encoded
@@ -56,7 +57,7 @@ impl From<io::Error> for Error {
     }
 }
 
-pub trait Serialize {
+pub(crate) trait Serialize {
     /// Write bytes into writer, subject to `max_bytes` limitations.
     ///
     /// # Errors

--- a/src/payload/common.rs
+++ b/src/payload/common.rs
@@ -1,17 +1,17 @@
 use arbitrary::Unstructured;
 
-const SIZES: [usize; 12] = [0, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048];
+const SIZES: [usize; 12] = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048];
 const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyz ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789().,";
 #[allow(clippy::cast_possible_truncation)]
 const CHARSET_LEN: u8 = CHARSET.len() as u8;
 
 #[derive(Debug, PartialEq)]
-pub struct AsciiStr {
+pub(crate) struct AsciiStr {
     bytes: Vec<u8>,
 }
 
 impl AsciiStr {
-    pub fn as_str(&self) -> &str {
+    pub(crate) fn as_str(&self) -> &str {
         // Safety: given that CHARSET is where we derive members from
         // `self.bytes` is always valid UTF-8.
         unsafe { std::str::from_utf8_unchecked(&self.bytes) }
@@ -31,6 +31,6 @@ impl<'a> arbitrary::Arbitrary<'a> for AsciiStr {
     }
 
     fn size_hint(_depth: usize) -> (usize, Option<usize>) {
-        (0, Some(2048))
+        (1, Some(2048))
     }
 }

--- a/src/payload/json.rs
+++ b/src/payload/json.rs
@@ -1,7 +1,9 @@
-use crate::payload::{Error, Serialize};
+use std::io::Write;
+
 use arbitrary::{size_hint, Arbitrary, Unstructured};
 use rand::Rng;
-use std::io::Write;
+
+use crate::payload::{Error, Serialize};
 
 const SIZES: [usize; 13] = [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048];
 
@@ -9,13 +11,13 @@ const SIZES: [usize; 13] = [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct Member {
     /// A u64. Its name has no meaning.
-    pub id: u64,
+    pub(crate) id: u64,
     /// A u64. Its name has no meaning.
-    pub name: u64,
+    pub(crate) name: u64,
     /// A u16. Its name has no meaning.
-    pub seed: u16,
+    pub(crate) seed: u16,
     /// A variable length array of bytes. Its name has no meaning.
-    pub byte_parade: Vec<u8>,
+    pub(crate) byte_parade: Vec<u8>,
 }
 
 impl<'a> Arbitrary<'a> for Member {
@@ -48,8 +50,8 @@ impl<'a> Arbitrary<'a> for Member {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct Json {}
+#[derive(Debug, Default, Clone, Copy)]
+pub(crate) struct Json {}
 
 impl Serialize for Json {
     fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
@@ -79,7 +81,7 @@ impl Serialize for Json {
 
 #[cfg(test)]
 mod test {
-    use quickcheck::{QuickCheck, TestResult};
+    use proptest::prelude::*;
     use rand::{rngs::SmallRng, SeedableRng};
 
     use super::Member;
@@ -87,9 +89,9 @@ mod test {
 
     // We want to be sure that the serialized size of the payload does not
     // exceed `max_bytes`.
-    #[test]
-    fn payload_not_exceed_max_bytes() {
-        fn inner(seed: u64, max_bytes: u16) -> TestResult {
+    proptest! {
+        #[test]
+        fn payload_not_exceed_max_bytes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let rng = SmallRng::seed_from_u64(seed);
             let json = Json::default();
@@ -97,19 +99,14 @@ mod test {
             let mut bytes = Vec::with_capacity(max_bytes);
             json.to_bytes(rng, max_bytes, &mut bytes).unwrap();
             assert!(bytes.len() <= max_bytes);
-
-            TestResult::passed()
         }
-        QuickCheck::new()
-            .tests(1_000)
-            .quickcheck(inner as fn(u64, u16) -> TestResult);
     }
 
     // We want to know that every payload produced by this type actually
     // deserializes as json, is not truncated etc.
-    #[test]
-    fn every_payload_deserializes() {
-        fn inner(seed: u64, max_bytes: u16) -> TestResult {
+    proptest! {
+        #[test]
+        fn every_payload_deserializes(seed: u64, max_bytes: u16) {
             let max_bytes = max_bytes as usize;
             let rng = SmallRng::seed_from_u64(seed);
             let json = Json::default();
@@ -121,11 +118,6 @@ mod test {
             for msg in payload.lines() {
                 let _members: Member = serde_json::from_str(msg).unwrap();
             }
-
-            TestResult::passed()
         }
-        QuickCheck::new()
-            .tests(1_000_000)
-            .quickcheck(inner as fn(u64, u16) -> TestResult);
     }
 }

--- a/src/payload/statik.rs
+++ b/src/payload/statik.rs
@@ -1,18 +1,20 @@
-use crate::payload::{Error, Serialize};
-use rand::Rng;
 use std::{
     io::{BufRead, Write},
     path::Path,
 };
 
+use rand::Rng;
+
+use crate::payload::{Error, Serialize};
+
 #[derive(Debug)]
-pub struct Static<'a> {
+pub(crate) struct Static<'a> {
     path: &'a Path,
 }
 
 impl<'a> Static<'a> {
     #[must_use]
-    pub fn new(path: &'a Path) -> Self {
+    pub(crate) fn new(path: &'a Path) -> Self {
         Self { path }
     }
 }

--- a/src/signals.rs
+++ b/src/signals.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+
 use tokio::{
     sync::broadcast,
     time::{interval, Duration},

--- a/src/target.rs
+++ b/src/target.rs
@@ -1,18 +1,20 @@
-pub use crate::common::{Behavior, Output};
-use crate::{common::stdio, signals::Shutdown};
-use nix::{
-    errno::Errno,
-    sys::signal::{kill, SIGTERM},
-    unistd::Pid,
-};
 use std::{
     collections::HashMap,
     io,
     path::PathBuf,
     process::{ExitStatus, Stdio},
 };
+
+use nix::{
+    errno::Errno,
+    sys::signal::{kill, SIGTERM},
+    unistd::Pid,
+};
 use tokio::process::Command;
 use tracing::{error, info};
+
+pub use crate::common::{Behavior, Output};
+use crate::{common::stdio, signals::Shutdown};
 
 #[derive(Debug)]
 pub enum Error {
@@ -28,6 +30,7 @@ pub struct Config {
     pub output: Output,
 }
 
+#[derive(Debug)]
 pub struct Server {
     config: Config,
     shutdown: Shutdown,


### PR DESCRIPTION
This commit converts from the quickcheck library to proptest. I've also started
to expand the properties checked here and have discovered that the ascii
serializer will kick out blank blocks. Oops. This has been a reported issue when
block sizes are small and will need some thinking over.

I think, also, I can unify some of these serializer tests by making the choice
of serializer random.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>