### PR TITLE
Set missing_docs deny

### DIFF
--- a/src/blackhole.rs
+++ b/src/blackhole.rs
@@ -1,3 +1,10 @@
+//! Lading blackholes
+//!
+//! For targets that need to push bytes themselves lading has b'blackhole'
+//! support. These are listening servers that catch payloads from the target, do
+//! as little as possible with them and respond as minimally as possible in
+//! order to avoid overhead.
+
 use serde::Deserialize;
 
 use crate::signals::Shutdown;
@@ -9,30 +16,51 @@ pub mod tcp;
 pub mod udp;
 
 #[derive(Debug)]
+/// Errors produced by [`Server`].
 pub enum Error {
+    /// See [`crate::blackhole::tcp::Error`] for details.
     Tcp(tcp::Error),
+    /// See [`crate::blackhole::http::Error`] for details.
     Http(http::Error),
+    /// See [`crate::blackhole::splunk_hec::Error`] for details.
     SplunkHec(splunk_hec::Error),
+    /// See [`crate::blackhole::udp::Error`] for details.
     Udp(udp::Error),
+    /// See [`crate::blackhole::sqs::Error`] for details.
     Sqs(sqs::Error),
 }
 
 #[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
+/// Configuration for [`Server`]
 pub enum Config {
+    /// See [`crate::blackhole::tcp::Config`] for details.
     Tcp(tcp::Config),
+    /// See [`crate::blackhole::http::Config`] for details.
     Http(http::Config),
+    /// See [`crate::blackhole::splunk_hec::Config`] for details.
     SplunkHec(splunk_hec::Config),
+    /// See [`crate::blackhole::udp::Config`] for details.
     Udp(udp::Config),
+    /// See [`crate::blackhole::sqs::Config`] for details.
     Sqs(sqs::Config),
 }
 
 #[derive(Debug)]
+/// The blackhole server.
+///
+/// All blackholes supported by lading are a variant of this enum. Please see
+/// variant documentation for details.
 pub enum Server {
+    /// See [`crate::blackhole::tcp::Tcp`] for details.
     Tcp(tcp::Tcp),
+    /// See [`crate::blackhole::http::Http`] for details.
     Http(http::Http),
+    /// See [`crate::blackhole::splunk_hec::SplunkHec`] for details.
     SplunkHec(splunk_hec::SplunkHec),
+    /// See [`crate::blackhole::udp::Udp`] for details.
     Udp(udp::Udp),
+    /// See [`crate::blackhole::sqs::Sqs`] for details.
     Sqs(sqs::Sqs),
 }
 

--- a/src/blackhole/http.rs
+++ b/src/blackhole/http.rs
@@ -1,3 +1,5 @@
+//! The HTTP protocol speaking blackhole.
+
 use std::{net::SocketAddr, str::FromStr, time::Duration};
 
 use hyper::{
@@ -21,13 +23,18 @@ fn default_concurrent_requests_max() -> usize {
 }
 
 #[derive(Debug)]
+/// Errors produced by [`Http`].
 pub enum Error {
+    /// Wrapper for [`hyper::Error`].
     Hyper(hyper::Error),
 }
 
 #[derive(Debug, Copy, Clone, Deserialize)]
+/// Body variant supported by this blackhole.
 pub enum BodyVariant {
+    /// All response bodies will be empty.
     Nothing,
+    /// All response bodies will mimic AWS Kinesis.
     AwsKinesis,
 }
 
@@ -47,7 +54,7 @@ fn default_body_variant() -> BodyVariant {
 }
 
 #[derive(Debug, Deserialize, Clone, Copy)]
-/// Main configuration struct for this program
+/// Configuration for [`Http`]
 pub struct Config {
     /// number of concurrent HTTP connections to allow
     #[serde(default = "default_concurrent_requests_max")]
@@ -122,6 +129,7 @@ async fn srv(
 }
 
 #[derive(Debug)]
+/// The HTTP blackhole.
 pub struct Http {
     httpd_addr: SocketAddr,
     body_variant: BodyVariant,

--- a/src/blackhole/splunk_hec.rs
+++ b/src/blackhole/splunk_hec.rs
@@ -130,7 +130,7 @@ async fn srv(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
 }
 
 #[derive(Debug)]
-/// The SplunkHec blackhole.
+/// The Splunk HEC blackhole.
 pub struct SplunkHec {
     concurrency_limit: usize,
     httpd_addr: SocketAddr,

--- a/src/blackhole/splunk_hec.rs
+++ b/src/blackhole/splunk_hec.rs
@@ -1,3 +1,5 @@
+//! The Splunk HEC protocol speaking blackhole.
+
 use std::{
     collections::HashMap,
     net::SocketAddr,
@@ -24,12 +26,14 @@ fn default_concurrent_requests_max() -> usize {
 }
 
 #[derive(Debug)]
+/// Errors produced by [`SplunkHec`].
 pub enum Error {
+    /// Wrapper for [`hyper::Error`].
     Hyper(hyper::Error),
 }
 
 #[derive(Debug, Deserialize, Clone, Copy)]
-/// Main configuration struct for this program
+/// Configuration for [`SplunkHec`].
 pub struct Config {
     /// number of concurrent HTTP connections to allow
     #[serde(default = "default_concurrent_requests_max")]
@@ -126,6 +130,7 @@ async fn srv(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
 }
 
 #[derive(Debug)]
+/// The SplunkHec blackhole.
 pub struct SplunkHec {
     concurrency_limit: usize,
     httpd_addr: SocketAddr,

--- a/src/blackhole/tcp.rs
+++ b/src/blackhole/tcp.rs
@@ -1,3 +1,5 @@
+//! The TCP protocol speaking blackhole.
+
 use std::{io, net::SocketAddr};
 
 use futures::stream::StreamExt;
@@ -10,17 +12,21 @@ use tracing::info;
 use crate::signals::Shutdown;
 
 #[derive(Debug)]
+/// Errors emitted by [`Tcp`]
 pub enum Error {
+    /// Wrapper for [`std::io::Error`].
     Io(io::Error),
 }
 
 #[derive(Debug, Deserialize, Clone, Copy)]
+/// Configuration for [`Tcp`]
 pub struct Config {
     /// address -- IP plus port -- to bind to
     binding_addr: SocketAddr,
 }
 
 #[derive(Debug)]
+/// The TCP blackhole.
 pub struct Tcp {
     binding_addr: SocketAddr,
     shutdown: Shutdown,

--- a/src/blackhole/udp.rs
+++ b/src/blackhole/udp.rs
@@ -1,3 +1,5 @@
+//! The UDP protocol speaking blackhole.
+
 use std::{io, net::SocketAddr};
 
 use metrics::counter;
@@ -8,18 +10,21 @@ use tracing::info;
 use crate::signals::Shutdown;
 
 #[derive(Debug)]
+/// Errors produced by [`Udp`].
 pub enum Error {
+    /// Wrapper for [`std::io::Error`].
     Io(io::Error),
 }
 
-/// Main configuration struct for this program
 #[derive(Debug, Deserialize, Clone, Copy)]
+/// Configuration for [`Udp`].
 pub struct Config {
     /// address -- IP plus port -- to bind to
     pub binding_addr: SocketAddr,
 }
 
 #[derive(Debug)]
+/// The UDP blackhole.
 pub struct Udp {
     binding_addr: SocketAddr,
     shutdown: Shutdown,

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,22 +3,24 @@ use std::{fmt, fs, path::PathBuf, process::Stdio, str};
 use serde::Deserialize;
 
 #[derive(Debug, Deserialize)]
+/// Defines how sub-process stderr and stdout are handled.
 pub struct Output {
     #[serde(default)]
+    /// Determines how stderr is routed.
     pub stderr: Behavior,
     #[serde(default)]
+    /// Determines how stderr is routed.
     pub stdout: Behavior,
 }
 
 #[derive(Debug, Deserialize, Clone)]
 #[serde(untagged)]
+/// Defines the [`Output`] behavior for stderr and stdout.
 pub enum Behavior {
     /// Redirect stdout, stderr to /dev/null
     Quiet,
-    Log(
-        /// Location to write stdio/stderr
-        PathBuf,
-    ),
+    /// Write to a location on-disk.
+    Log(PathBuf),
 }
 
 impl Default for Behavior {

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,13 +27,18 @@ pub struct Config {
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
 #[serde(untagged)]
+/// Defines the manner of lading's telemetry.
 pub enum Telemetry {
+    /// In prometheus mode lading will emit its internal telemetry for scraping
+    /// at a prometheus poll endpoint.
     Prometheus {
         /// Address and port for prometheus exporter
         prometheus_addr: SocketAddr,
         /// Additional labels to include in every metric
         global_labels: HashMap<String, String>,
     },
+    /// In log mode lading will emit its internal telemetry to a structured log
+    /// file, the "capture" file.
     Log {
         /// Location on disk to write captures
         path: PathBuf,

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -1,3 +1,15 @@
+//! Lading generators
+//!
+//! The lading generator is responsible for pushing load into the target
+//! sub-process via a small handful of protocols, the variants of
+//! [`Server`]. Each generator variant works in the same basic way: a block of
+//! payloads are pre-computed at generator start time which are then spammed
+//! into the target according to a user-defined rate limit in a cyclic
+//! manner. That is, we avoid runtime delays in payload generation by, well,
+//! building a lot of payloads in one shot and rotating through them
+//! indefinately, paying higher memory and longer startup for better
+//! experimental control.
+
 use serde::Deserialize;
 
 use crate::signals::Shutdown;
@@ -9,30 +21,51 @@ pub mod splunk_hec;
 pub mod tcp;
 
 #[derive(Debug)]
+/// Errors produced by [`Server`].
 pub enum Error {
+    /// See [`crate::generator::tcp::Error`] for details.
     Tcp(tcp::Error),
+    /// See [`crate::generator::http::Error`] for details.
     Http(http::Error),
+    /// See [`crate::generator::splunk_hec::Error`] for details.
     SplunkHec(splunk_hec::Error),
+    /// See [`crate::generator::kafka::Error`] for details.
     Kafka(kafka::Error),
+    /// See [`crate::generator::file_gen::Error`] for details.
     FileGen(file_gen::Error),
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Configuration for [`Server`]
 pub enum Config {
+    /// See [`crate::generator::tcp::Config`] for details.
     Tcp(tcp::Config),
+    /// See [`crate::generator::http::Config`] for details.
     Http(http::Config),
+    /// See [`crate::generator::splunk_hec::Config`] for details.
     SplunkHec(splunk_hec::Config),
+    /// See [`crate::generator::kafka::Config`] for details.
     Kafka(kafka::Config),
+    /// See [`crate::generator::file_gen::Config`] for details.
     FileGen(file_gen::Config),
 }
 
 #[derive(Debug)]
+/// The generator server.
+///
+/// All generators supported by lading are a variant of this enum. Please see
+/// variant documentation for details.
 pub enum Server {
+    /// See [`crate::generator::tcp::Tcp`] for details.
     Tcp(tcp::Tcp),
+    /// See [`crate::generator::http::Http`] for details.
     Http(http::Http),
+    /// See [`crate::generator::splunk_hec::SplunkHec`] for details.
     SplunkHec(splunk_hec::SplunkHec),
+    /// See [`crate::generator::kafka::Kafka`] for details.
     Kafka(kafka::Kafka),
+    /// See [`crate::generator::file_gen::FileGen`] for details.
     FileGen(file_gen::FileGen),
 }
 

--- a/src/generator/http.rs
+++ b/src/generator/http.rs
@@ -1,3 +1,5 @@
+//! The HTTP protocol speaking generator.
+
 use std::{
     num::{NonZeroU32, NonZeroUsize},
     path::PathBuf,
@@ -45,6 +47,7 @@ pub enum Method {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "snake_case")]
+/// Variants supported by this generator.
 pub enum Variant {
     /// Generates Splunk HEC messages
     SplunkHec,
@@ -65,6 +68,7 @@ pub enum Variant {
 }
 
 #[derive(Debug, Deserialize)]
+/// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target
     pub seed: [u8; 32],
@@ -85,11 +89,18 @@ pub struct Config {
 }
 
 #[derive(Debug)]
+/// Errors produced by [`Http`].
 pub enum Error {
+    /// Rate limiter has insuficient capacity for payload. Indicates a serious
+    /// bug.
     Governor(InsufficientCapacity),
+    /// Wrapper around [`std::io::Error`].
     Io(::std::io::Error),
+    /// Creation of payload blocks failed.
     Block(block::Error),
+    /// Wrapper around [`hyper::Error`].
     Hyper(hyper::Error),
+    /// Wrapper around [`hyper::http::Error`].
     Http(hyper::http::Error),
 }
 
@@ -123,8 +134,10 @@ impl From<::std::io::Error> for Error {
     }
 }
 
-/// The [`Worker`] defines a task that emits variant lines to an HTTP server
-/// controlling throughput.
+/// The HTTP generator.
+///
+/// This generator is reposnsible for connecting to the target via HTTP. Today
+/// only POST and GET are supported.
 #[derive(Debug)]
 pub struct Http {
     uri: Uri,
@@ -138,7 +151,7 @@ pub struct Http {
 }
 
 impl Http {
-    /// Create a new [`Worker`] instance
+    /// Create a new [`Http`] instance
     ///
     /// # Errors
     ///
@@ -237,7 +250,7 @@ impl Http {
         }
     }
 
-    /// Enter the main loop of this [`Worker`]
+    /// Run [`Http`] to completion or until a shutdown signal is received.
     ///
     /// # Errors
     ///

--- a/src/generator/splunk_hec.rs
+++ b/src/generator/splunk_hec.rs
@@ -1,4 +1,4 @@
-//! The SplunkHec generator.
+//! The Splunk HEC generator.
 
 mod acknowledgements;
 

--- a/src/generator/splunk_hec.rs
+++ b/src/generator/splunk_hec.rs
@@ -1,3 +1,5 @@
+//! The SplunkHec generator.
+
 mod acknowledgements;
 
 use std::{
@@ -47,7 +49,7 @@ pub struct AckSettings {
     pub ack_timeout_seconds: u64,
 }
 
-/// The [`Target`] instance from which to derive workers
+/// Configuration for [`SplunkHec`]
 #[derive(Deserialize, Debug)]
 pub struct Config {
     /// The seed for random operations against this target
@@ -72,9 +74,13 @@ pub struct Config {
 }
 
 #[derive(Debug, Clone, Copy)]
+/// Errors produced by [`SplunkHec`].
 pub enum Error {
+    /// User supplied HEC path is invalid.
     InvalidHECPath,
+    /// Interior acknowledgement error.
     Acknowledgements(acknowledgements::Error),
+    /// Creation of payload blocks failed.
     Block(block::Error),
 }
 
@@ -84,8 +90,8 @@ impl From<block::Error> for Error {
     }
 }
 
-/// The [`Worker`] defines a task that emits variant lines to a Splunk HEC
-/// server controlling throughput.
+/// Defines a task that emits variant lines to a Splunk HEC server controlling
+/// throughput.
 #[derive(Debug)]
 pub struct SplunkHec {
     uri: Uri,
@@ -115,7 +121,7 @@ fn get_uri_by_format(base_uri: &Uri, format: payload::SplunkHecEncoding) -> Uri 
 }
 
 impl SplunkHec {
-    /// Create a new [`Worker`] instance
+    /// Create a new [`SplunkHec`] instance
     ///
     /// # Errors
     ///
@@ -177,7 +183,7 @@ impl SplunkHec {
         })
     }
 
-    /// Enter the main loop of this [`Worker`]
+    /// Run [`SplunkHec`] to completion or until a shutdown signal is received.
     ///
     /// # Errors
     ///

--- a/src/generator/tcp.rs
+++ b/src/generator/tcp.rs
@@ -1,3 +1,5 @@
+//! The TCP protocol speaking generator.
+
 use std::{
     net::{SocketAddr, ToSocketAddrs},
     num::{NonZeroU32, NonZeroUsize},
@@ -22,6 +24,7 @@ use crate::{
 };
 
 #[derive(Debug, Deserialize)]
+/// Configuration of this generator.
 pub struct Config {
     /// The seed for random operations against this target
     pub seed: [u8; 32],
@@ -39,6 +42,7 @@ pub struct Config {
 
 #[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "snake_case")]
+/// Variants supported by this generator.
 pub enum GeneratorVariant {
     /// Generates Fluent messages
     Fluent,
@@ -47,8 +51,12 @@ pub enum GeneratorVariant {
 }
 
 #[derive(Debug)]
+/// Errors produced by [`Tcp`].
 pub enum Error {
+    /// Rate limiter has insuficient capacity for payload. Indicates a serious
+    /// bug.
     Governor(InsufficientCapacity),
+    /// Creation of payload blocks failed.
     Block(block::Error),
 }
 
@@ -65,6 +73,9 @@ impl From<InsufficientCapacity> for Error {
 }
 
 #[derive(Debug)]
+/// The TCP generator.
+///
+/// This generator is responsible for connecting to the target via TCP
 pub struct Tcp {
     addr: SocketAddr,
     rate_limiter: RateLimiter<direct::NotKeyed, state::InMemoryState, clock::QuantaClock>,
@@ -74,7 +85,7 @@ pub struct Tcp {
 }
 
 impl Tcp {
-    /// Create a new [`Server`] instance
+    /// Create a new [`Tcp`] instance
     ///
     /// # Errors
     ///
@@ -144,7 +155,7 @@ impl Tcp {
         })
     }
 
-    /// Enter the main loop of this [`Worker`]
+    /// Run [`Tcp`] to completion or until a shutdown signal is received.
     ///
     /// # Errors
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,10 @@
+//! The lading daemon load generation and introspection tool.
+//!
+//! This library support the lading binary found elsewhere in this project. The
+//! bits and pieces here are not intended to be used outside of supporting
+//! lading, although if they are helpful in other domains that's a nice
+//! surprise.
+
 #![deny(clippy::all)]
 #![deny(clippy::cargo)]
 #![deny(clippy::pedantic)]
@@ -6,6 +13,7 @@
 #![deny(unused_assignments)]
 #![deny(unused_comparisons)]
 #![deny(unreachable_pub)]
+#![deny(missing_docs)]
 #![deny(missing_copy_implementations)]
 #![deny(missing_debug_implementations)]
 #![allow(clippy::cast_precision_loss)]


### PR DESCRIPTION
This commit requires that all public exports of the lading crate be
documented. What is here now is at least an okay first-pass but the README needs
to be properly updated to explain how the project works, is meant to be used
etc.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>