### PR TITLE
Avoid qemu emulation in release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2.3.5
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v1
-
       - name: Set up Docker Buildx
         id: buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        platform: [linux/amd64, linux/arm64]
+        platform: [linux/amd64]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
The use of QEMU makes the release build on ARM ruinously slow. Also, recently,
mysteriously, the jobs have been failing with a KILLED message. Absent any
further information I'm at least interested in getting the ARM build to fail
faster.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>