### PR TITLE
Collect CPU, memory, scheduling information about the target process

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -414,6 +414,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "http"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -540,6 +546,7 @@ dependencies = [
  "metrics-util",
  "nix",
  "once_cell",
+ "procfs",
  "proptest",
  "rand",
  "rdkafka",
@@ -967,6 +974,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
+]
+
+[[package]]
+name = "procfs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0941606b9934e2d98a3677759a971756eb821f75764d0e0d26946d08e74d9104"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "hex",
+ "lazy_static",
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,9 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["std", "env-filter"] }
 uuid =  { version = "1.0", features = ["serde", "v4"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+procfs = { version = "0.12", default-features = false, features = [] }
+
 [dev-dependencies]
 proptest = "1.0"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,7 @@ use std::{collections::HashMap, net::SocketAddr, path::PathBuf};
 
 use serde::Deserialize;
 
-use crate::{blackhole, generator, inspector, target};
+use crate::{blackhole, generator, inspector, observer, target};
 
 /// Main configuration struct for this program
 #[derive(Debug, Deserialize)]
@@ -15,6 +15,9 @@ pub struct Config {
     pub telemetry: Telemetry,
     /// The generator to apply to the target in-rig
     pub generator: generator::Config,
+    /// The observer that watches the target
+    #[serde(skip_deserializing)]
+    pub observer: observer::Config,
     /// The program being targetted by this rig
     #[serde(skip_deserializing)]
     pub target: Option<target::Config>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ mod common;
 pub mod config;
 pub mod generator;
 pub mod inspector;
+pub mod observer;
 pub(crate) mod payload;
 pub mod signals;
 pub mod target;

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -100,11 +100,11 @@ impl Server {
         let ticks_per_second: u64 = procfs::ticks_per_second()
             .expect("cannot determine ticks per second")
             .try_into()
-            .unwrap();
+            .expect("cannot convert ticks to u64");
         let page_size: u64 = procfs::page_size()
             .expect("cannot determinte page size")
             .try_into()
-            .unwrap();
+            .expect("cannot convert page size to u64");
 
         gauge!("page_size", page_size as f64);
         gauge!("ticks_per_second", ticks_per_second as f64);

--- a/src/observer.rs
+++ b/src/observer.rs
@@ -1,0 +1,145 @@
+//! Manage the target observer
+//!
+//! The interogation that lading does of the target sub-process is intentionally
+//! limited to in-process concerns, for the most part. The 'inspector' does
+//! allow for a sub-process to do out-of-band inspection of the target but
+//! cannot incorporate whatever it's doing into the capture data that lading
+//! produces. This observer, on Linux, looks up the target process in procfs and
+//! writes out key details about memory and CPU consumption into the capture
+//! data. On non-Linux systems the observer, if enabled, will emit a warning.
+
+use std::io;
+
+use nix::errno::Errno;
+use serde::Deserialize;
+use tokio::{sync::broadcast::Receiver, time};
+use tracing::info;
+
+use crate::signals::Shutdown;
+
+#[cfg(target_os = "linux")]
+use procfs::process::Process;
+
+#[derive(Debug)]
+/// Errors produced by [`Server`]
+pub enum Error {
+    /// Wrapper for [`nix::errno::Errno`]
+    Errno(Errno),
+    /// Wrapper for [`std::io::Error`]
+    Io(io::Error),
+    #[cfg(target_os = "linux")]
+    /// Wrapper for [`procfs::ProcError`]
+    ProcError(procfs::ProcError),
+}
+
+#[derive(Debug, Deserialize, Clone, Copy, Default)]
+#[serde(rename_all = "snake_case")]
+/// Configuration for [`Server`]
+pub struct Config {}
+
+#[derive(Debug)]
+/// The inspector sub-process server.
+///
+/// This struct manages a sub-process that can be used to do further examination
+/// of the [`crate::target::Server`] by means of operating system facilities. The
+/// sub-process is not created until [`Server::run`] is called. It is assumed
+/// that only one instance of this struct will ever exist at a time, although
+/// there are no protections for that.
+pub struct Server {
+    #[allow(dead_code)] // config is not actively used, left as a stub
+    config: Config,
+    shutdown: Shutdown,
+}
+
+impl Server {
+    /// Create a new [`Server`] instance
+    ///
+    /// The observer `Server` is responsible for investigating the
+    /// [`crate::target::Server`] sub-process.
+    ///
+    /// # Errors
+    ///
+    /// Function will error if the path to the sub-process is not valid or if
+    /// the path is valid but is not to file executable by this program.
+    pub fn new(config: Config, shutdown: Shutdown) -> Result<Self, Error> {
+        Ok(Self { config, shutdown })
+    }
+
+    /// Run this [`Server`] to completion
+    ///
+    /// This function runs the user supplied program to its completion, or until
+    /// a shutdown signal is received. Child exit status does not currently
+    /// propagate. This is less than ideal.
+    ///
+    /// Target server will use the `broadcast::Sender` passed here to transmit
+    /// its PID. This PID is passed to the sub-process as the first argument.
+    ///
+    /// # Errors
+    ///
+    /// Function will return an error if the underlying program cannot be waited
+    /// on or will not shutdown when signaled to.
+    ///
+    /// # Panics
+    ///
+    /// None are known.
+    #[cfg(target_os = "linux")]
+    pub async fn run(mut self, mut pid_snd: Receiver<u32>) -> Result<(), Error> {
+        use std::time::Duration;
+
+        use metrics::{counter, gauge};
+
+        let target_pid = pid_snd
+            .recv()
+            .await
+            .expect("target failed to transmit PID, catastrophic failure");
+        drop(pid_snd);
+
+        let process = Process::new(target_pid.try_into().expect("PID coercion failed"))
+            .map_err(Error::ProcError)?;
+
+        let ticks_per_second: u64 = procfs::ticks_per_second()
+            .expect("cannot determine ticks per second")
+            .try_into()
+            .unwrap();
+        let page_size: u64 = procfs::page_size()
+            .expect("cannot determinte page size")
+            .try_into()
+            .unwrap();
+
+        gauge!("page_size", page_size as f64);
+        gauge!("ticks_per_second", ticks_per_second as f64);
+
+        let mut procfs_delay = time::interval(Duration::from_secs(1));
+
+        loop {
+            tokio::select! {
+                _ = procfs_delay.tick() => {
+                    if let Ok(stat) = process.stat() {
+                        // Number of pages that the process has in real memory.
+                        gauge!("rss_pages", stat.rss as f64);
+                        // Soft limit on RSS bytes, see RLIMIT_RSS in getrlimit(2).
+                        gauge!("rsslim_bytes", stat.rsslim as f64);
+                        // Number of threads this process has active.
+                        gauge!("num_threads", stat.num_threads as f64);
+                        // The number of ticks -- reference ticks_per_second -- that the
+                        // process has spent scheduled in user-mode.
+                        counter!("utime_ticks", stat.utime);
+                        // The number of ticks -- reference ticks_per_second -- that the
+                        // process has spent scheduled in kernel-mode.
+                        counter!("stime_ticks", stat.stime);
+                        // The size in bytes of the process in virtual memory.
+                        counter!("vsize_bytes", stat.vsize);
+                    }
+                }
+                _ = self.shutdown.recv() => {
+                    info!("shutdown signal received");
+                    return Ok(());
+                }
+            }
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    pub async fn run(mut self, _pid_snd: Receiver<u32>) -> Result<ExitStatus, Error> {
+        warn!("observer unavailable on non-Linux system");
+    }
+}


### PR DESCRIPTION
This commit introduces procfs dependency to the project and uses it to power an
'observer' server that runs as a peer to the target etc. This observer is
responsible for periodically reading the /proc/PID/stat of the target process,
writing out interesting details regarding memory consumption, CPU and scheduling
time. In this commit we collect:

* page_size -- the memory page size of the OS in bytes
* ticks_per_second -- the OS ticks that happen in a second
* rss_pages -- the real memory pages the process has allocated
* rsslim_bytes -- the soft limit of RSS in bytes
* num_threads -- the number of threads the process has running
* utime_ticks -- the number of ticks the process has spent scheduled in user-space
* stime_ticks -- the number of ticks the process has spent scheduled in kernel-space
* vsize_bytes -- the size in bytes of the process' virtual memory

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>