### PR TITLE
Allow static payload to take a directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,4 +55,3 @@ name = "lading"
 lto = true        # Optimize our binary at link stage.
 codegen-units = 1 # Increases compile time but improves optmization alternatives.
 opt-level = 3     # Optimize with 'all' optimization flipped on. May produce larger binaries than 's' or 'z'.
-debug = true

--- a/src/blackhole/http.rs
+++ b/src/blackhole/http.rs
@@ -11,7 +11,7 @@ use hyper::{
 use once_cell::unsync::OnceCell;
 use serde::{Deserialize, Serialize};
 use tower::ServiceBuilder;
-use tracing::{error, info};
+use tracing::{debug, error, info};
 
 use crate::signals::Shutdown;
 
@@ -163,7 +163,10 @@ impl Http {
     /// None known.
     pub async fn run(mut self) -> Result<(), Error> {
         let service = make_service_fn(|_: &AddrStream| async move {
-            Ok::<_, hyper::Error>(service_fn(move |request| srv(self.body_variant, request)))
+            Ok::<_, hyper::Error>(service_fn(move |request| {
+                debug!("REQUEST: {:?}", request);
+                srv(self.body_variant, request)
+            }))
         });
         let svc = ServiceBuilder::new()
             .load_shed()

--- a/src/payload/statik.rs
+++ b/src/payload/statik.rs
@@ -1,46 +1,92 @@
 use std::{
+    fs,
     io::{BufRead, Write},
-    path::Path,
+    path::{Path, PathBuf},
 };
 
-use rand::Rng;
+use rand::{prelude::IteratorRandom, Rng};
 
 use crate::payload::{Error, Serialize};
 
 #[derive(Debug)]
-pub(crate) struct Static<'a> {
-    path: &'a Path,
+struct Source {
+    byte_size: u64,
+    path: PathBuf,
 }
 
-impl<'a> Static<'a> {
+#[derive(Debug)]
+pub(crate) struct Static {
+    sources: Vec<Source>,
+}
+
+impl Static {
     #[must_use]
-    pub(crate) fn new(path: &'a Path) -> Self {
-        Self { path }
+    pub(crate) fn new(path: &Path) -> Self {
+        let mut sources = Vec::with_capacity(16);
+
+        if path.is_file() {
+            let file = std::fs::OpenOptions::new()
+                .read(true)
+                .open(path)
+                .expect("could not open file");
+            let byte_size = file.metadata().expect("could not read file metadata").len();
+            sources.push(Source {
+                byte_size,
+                path: path.to_owned(),
+            });
+        } else if path.is_dir() {
+            for entry in fs::read_dir(path).expect("could not read directory") {
+                let entry = entry.unwrap();
+                let entry_pth = entry.path();
+                if entry_pth.is_dir() {
+                    // intentionally skip sub-directories
+                    continue;
+                } else {
+                    let file = std::fs::OpenOptions::new()
+                        .read(true)
+                        .open(&entry_pth)
+                        .expect("could not open file");
+                    let byte_size = file.metadata().expect("could not read file metadata").len();
+                    sources.push(Source {
+                        byte_size,
+                        path: entry_pth.to_owned(),
+                    });
+                }
+            }
+        } else {
+            panic!("discovered a path to something that is neither file nor directory");
+        }
+
+        Self { sources }
     }
 }
 
-impl<'a> Serialize for Static<'a> {
-    fn to_bytes<W, R>(&self, _rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
+impl Serialize for Static {
+    fn to_bytes<W, R>(&self, mut rng: R, max_bytes: usize, writer: &mut W) -> Result<(), Error>
     where
         R: Rng + Sized,
         W: Write,
     {
-        // Read lines from `static_path` until such time as the total byte
-        // length of the lines read exceeds `bytes_max`. If the path contains
-        // more bytes than `bytes_max` the tail of the file will be chopped off.
-        let file = std::fs::OpenOptions::new().read(true).open(self.path)?;
-        let mut reader = std::io::BufReader::new(file);
+        // Filter available static files to those with size less than
+        // max_bytes. Of the remaining, randomly choose one and write it out. We
+        // do not change the structure of the file in any respect; it is
+        // faithfully transmitted.
 
-        let mut bytes_remaining = max_bytes;
-        let mut line = String::new();
-        while bytes_remaining > 0 {
-            let len = reader.read_line(&mut line)?;
-            if len > bytes_remaining {
-                break;
-            }
+        let subset = self
+            .sources
+            .iter()
+            .filter(|src| src.byte_size < max_bytes as u64);
+        if let Some(source) = subset.choose(&mut rng) {
+            // Read lines from `static_path` until such time as the total byte
+            // length of the lines read exceeds `bytes_max`. If the path contains
+            // more bytes than `bytes_max` the tail of the file will be chopped off.
+            let file = std::fs::OpenOptions::new().read(true).open(&source.path)?;
 
-            writer.write_all(line.as_bytes())?;
-            bytes_remaining = bytes_remaining.saturating_sub(line.len());
+            let mut reader = std::io::BufReader::new(file);
+            let buffer = reader.fill_buf()?;
+            let buffer_length = buffer.len();
+            writer.write_all(buffer)?;
+            reader.consume(buffer_length);
         }
 
         Ok(())

--- a/src/payload/statik.rs
+++ b/src/payload/statik.rs
@@ -5,6 +5,7 @@ use std::{
 };
 
 use rand::{prelude::IteratorRandom, Rng};
+use tracing::info;
 
 use crate::payload::{Error, Serialize};
 
@@ -25,6 +26,7 @@ impl Static {
         let mut sources = Vec::with_capacity(16);
 
         // Attempt to open the path, if this fails we assume that it is a directory.
+        info!("attempting to open {} as file", path.display());
         match std::fs::OpenOptions::new().read(true).open(path) {
             Ok(file) => {
                 let byte_size = file.metadata().expect("could not read file metadata").len();
@@ -37,6 +39,7 @@ impl Static {
                 for entry in fs::read_dir(path).expect("could not read directory") {
                     let entry = entry.unwrap();
                     let entry_pth = entry.path();
+                    info!("attempting to open {} as file", entry_pth.display());
                     if let Ok(file) = std::fs::OpenOptions::new().read(true).open(&entry_pth) {
                         let byte_size =
                             file.metadata().expect("could not read file metadata").len();
@@ -69,9 +72,7 @@ impl Serialize for Static {
             .iter()
             .filter(|src| src.byte_size < max_bytes as u64);
         if let Some(source) = subset.choose(&mut rng) {
-            // Read lines from `static_path` until such time as the total byte
-            // length of the lines read exceeds `bytes_max`. If the path contains
-            // more bytes than `bytes_max` the tail of the file will be chopped off.
+            info!("attempting to open {} as file", &source.path.display());
             let file = std::fs::OpenOptions::new().read(true).open(&source.path)?;
 
             let mut reader = std::io::BufReader::new(file);


### PR DESCRIPTION
This commit modifies the static generator to take either a file or a
directory. The block sizes are used as filters now, meaning we no longer assume
files can be arbitrarily truncated on line boundaries and instead pass the whole
file forward if `max_bytes` is sufficient to do so. It is up to the preparer of
static data to guarantee sufficient entropy.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>