### PR TITLE
Allow file_gen users to decide on rotation

### DIFF
--- a/src/generator/file_gen.rs
+++ b/src/generator/file_gen.rs
@@ -298,6 +298,7 @@ impl Child {
 
             {
                 fp.write_all(block).await?;
+                fp.flush().await?;
                 // block.len() and total_bytes are the same numeric value but we
                 // avoid needing to get a plain value from a non-zero by calling
                 // len here.


### PR DESCRIPTION
Previously the file generator would write to the end of its file, delete the
file and then start over with the same name. This caused some tailing programs
to perform strangely. That said, it's not necessarily interesting to _always_
remove handles and in some cases users would like to experiment with the tailer
doing file removal.

This is now possible. File generator will now always increment the file index
whether rotation is on or not but does allow the user to decide if rotation
happens, which it does by default.

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>