### PR TITLE
Support multiple generators and blackholes

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,38 @@ use serde::Deserialize;
 
 use crate::{blackhole, generator, inspector, observer, target};
 
+/// Generator configuration for this program.
+///
+/// We have many uses that exist prior to the introduction of multiple
+/// generators, meaning many configs that _assume_ there is only one generator
+/// and that they do not exist in an array. In order to avoid breaking those
+/// configs we support this goofy structure. A deprecation cycle here is in
+/// order someday.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum Generator {
+    /// Load in only one generator
+    One(Box<generator::Config>),
+    /// Load in one or more generators
+    Many(Vec<generator::Config>),
+}
+
+/// Blackhole configuration for this program.
+///
+/// We have many uses that exist prior to the introduction of multiple
+/// blackholes, meaning many configs that _assume_ there is only one bloackhole
+/// and that they do not exist in an array. In order to avoid breaking those
+/// configs we support this goofy structure. A deprecation cycle here is in
+/// order someday.
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum Blackhole {
+    /// Load in only one generator
+    One(Box<blackhole::Config>),
+    /// Load in one or more generators
+    Many(Vec<blackhole::Config>),
+}
+
 /// Main configuration struct for this program
 #[derive(Debug, Deserialize)]
 pub struct Config {
@@ -14,7 +46,7 @@ pub struct Config {
     #[serde(default)]
     pub telemetry: Telemetry,
     /// The generator to apply to the target in-rig
-    pub generator: generator::Config,
+    pub generator: Generator,
     /// The observer that watches the target
     #[serde(skip_deserializing)]
     pub observer: observer::Config,
@@ -22,7 +54,7 @@ pub struct Config {
     #[serde(skip_deserializing)]
     pub target: Option<target::Config>,
     /// The blackhole to supply for the target
-    pub blackhole: Option<blackhole::Config>,
+    pub blackhole: Option<Blackhole>,
     /// The target inspector sub-program
     pub inspector: Option<inspector::Config>,
 }


### PR DESCRIPTION
This commit allows the user to configure lading to have multiple generators and
blackholes, enabling more complex testing of targets. Vector project is expected
to make good use of this capability.

No guarantees are made about ordering at startup and shutdown, except those that
already exist.

Resolves #227

Signed-off-by: Brian L. Troutwine <brian@troutwine.us>