### PR TITLE
Prepare lading for move under Datadog org.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+### What does this PR do?
+
+A brief description of the change being made with this pull request.
+
+### Motivation
+
+What inspired you to submit this pull request?
+
+### Related issues
+
+A list of issues either fixed, containing architectural discussions, otherwise relevant
+for this Pull Request.
+
+### Additional Notes
+
+Anything else we should know when reviewing?

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,12 @@ on:
       - main
 
 jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: EmbarkStudios/cargo-deny-action@v1
+
   check:
     name: Check
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing
+
+Thank you for contributing to `lading`! We find `lading` very useful for our
+work and hope you have as well and are interested in incorporating your changes
+in a timely fashion. To help us help you we ask that you follow a handful of
+guidelines when crafting your change.
+
+## Guidelines
+
+0. Please send us changes as PRs. We don't have any constraints on branch names
+   but do please add descriptive commit messages to your PR. We provide a
+   template for your convenience.
+
+0. Do consider tagging reviewers only after CI checks are green.
+
+0. Do consider that the smaller your change the easier it is to review and the
+   more likely we are to incorporate it. If you have a big change in mind, let's
+   hash it out in an issue first, just so we agree on your idea before you put
+   the time into it.
+
+0. Test your changes, both in test code and by running `lading` with your
+   changes in place. Preferentially we make use of property tests in this
+   project. We can help you write those if you've never done property testing.
+
+0. We require signed commits. Github's
+   [documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification)
+   is a big help at getting this set up.
+
+0. If you add a dependency please be aware that we require licenses to conform
+   to the set listed in our
+   [cargo-deny](https://github.com/EmbarkStudios/cargo-deny)
+   configuration. License check is part of the CI workflow.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2021, Brian L. Troutwine <brian@troutwine.us>
+Copyright 2021-2022, Datadog, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/LICENSE-3rdparty.sh
+++ b/LICENSE-3rdparty.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env sh
+
+set -o errexit
+set -o pipefail
+set -o nounset
+# set -o xtrace
+
+rm -f cargo.lock > /dev/null
+cargo install cargo-license > /dev/null
+cargo license --all-features -a -j --no-deps -d | jq -r '(["Component","Origin","License","Copyright"]) as $cols | map(. as $row | ["name", "repository", "license", "authors"] | map($row[.])) as $rows | $cols, $rows[] | @csv'

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+Datadog Lading
+Copyright 2021-2022 Datadog, Inc.
+
+This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/README.md
+++ b/README.md
@@ -1,28 +1,92 @@
-# `lading` - A tool for measuring the performance of daemons.
+# `lading` - A tool for measuring the performance of long-running programs.
 
-The `lading` binary in this project is a tool for measuring the performance
-behavior of long-running programs -- daemons -- using synthetic load. Consider
-the following `lading.yaml`:
+The `lading` project is a tool for measuring the performance behavior of
+long-running programs -- daemons, often -- using synthetic, repeatable load
+generation across a variety of protocols. The ambition is to be a worry-free
+component of a larger performance testing strategy for complex programs. The
+[Vector][vector] project uses lading in their 'soak' tests.
+
+## Operating Model
+
+`lading` operates on three conceptual components:
+
+* generators,
+* target and
+* blackholes
+
+A "generator" in `lading` is responsible for creating load and "pushing" it into
+the target. The "target" in is the program that `lading` runs as a sub-process,
+collecting resource consumption data about the target from the operating system
+but also self-telemetry regarding generation. The "blackhole" exists for targets
+to push load into, when necessary, allowing for a target to be run and examined
+by `lading` without including external programs or APIs into the setup.
+
+As much as possible `lading` pre-computes any generator and blackhole payloads,
+intending to minimize runtime overhead compared to the target program. Users
+must provide a seed to `lading` -- see below -- ensuring that payloads are
+generated in a repeatable manner across `lading` runs. While pre-computation
+does mean that `lading` is capable of outpacing many targets with minimal
+runtime interference it does also mean higher memory use compared to other load
+generation tools.
+
+## Configuration
+
+The configuration of `lading` is split between a configuration file in YAML
+format and command-line options. Generators and blackholes are configured in the
+config file, targets on the command line. This is, at first glance, awkward but
+does allow for `lading` to be used in dynamic environments like CI without
+foreknowledge of the target.
+
+That "push" can be as direct as network IO into the target, as indirect as doing file operations for a target whose
+
+Consider the following `lading.yaml`:
 
 ```yaml
 generator:
-  tcp:
+  http:
     seed: [2, 3, 5, 7, 11, 13, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137]
-    addr: "0.0.0.0:8282"
-    variant: "syslog5424"
-    bytes_per_second: "500 Mb"
-    block_sizes: ["1Mb", "0.5Mb", "0.25Mb", "0.125Mb", "128Kb"]
-    maximum_prebuild_cache_size_bytes: "256 Mb"
+    target_uri: "http://localhost:8282/"
+    bytes_per_second: "100 Mb"
+    parallel_connections: 10
+    method:
+      post:
+        variant: "fluent"
+        maximum_prebuild_cache_size_bytes: "256 Mb"
+    headers: {}
 
 blackhole:
-  tcp:
+  http:
     binding_addr: "0.0.0.0:8080"
 ```
 
-The `generator` defines where load comes from into the target, the `blackhole`
-where the target program's output goes to, if necessary. Setup of the target and
-telemetry are handled by command line flags. By default `lading` will expose a
-prometheus endpoint but in the above lading is in "capture file" mode. The
-`generator` in the above emits syslog style lines into the target. Targets are
-programs run as sub-processes. The `blackhole` is a simple TCP server on
-`:8080`.
+In this setup `lading` is configured to run one generator and one blackhole. In
+general, at least one generator is required and zero or more blackholes are. The
+generator here, named "http", uses a fixed seed to repeatably produce [fluent's
+forward protocol][fluent] instances at 100 Mb per second into the target, with a
+pre-built size of 256 Mb. That is, `lading` will _attempt_ to push at a fixed
+throughput, although the target might not be able to cope with that load and
+`lading` will consume 256 Mb of RAM to accommodate pre-build payloads. The
+blackhole in this configuration responds with an empty body 200 OK.
+
+`lading` acts like a wrapper around the target, so running `lading` one
+specifies where on disk the configuration is, the path to the target and its
+arguments. `--target-stderr-path` and `--target-stdout-path` allow the target's
+stdout, stderr to be forwarded into files. At runtime `lading` will output
+diagnostic information on its stdout about the current state of the target. The
+data `lading` captures at runtime can be pulled by polling `lading`'s prometheus
+endpoint -- configurable with `--prometheus-addr` -- or can be written to disk
+by lading by specifying `--capture-path`. The captured data, when written to
+disk, is newline delimited json payloads.
+
+## Contributing
+
+See [Contributing][contributing].
+
+## License
+
+Licensed under the [MIT license][mit-license].
+
+[contributing]: CONTRIBUTING.md
+[mit-license]: LICENSE
+[vector]: github.com/vectordotdev/vector
+[fluent]: https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,25 @@
+[licenses]
+allow = [
+  "MIT",
+  "CC0-1.0",
+  "ISC",
+  "OpenSSL",
+  "Unlicense",
+  "BSD-2-Clause",
+  "BSD-3-Clause",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "Zlib",
+]
+
+copyleft = "deny"
+default = "deny"
+
+[advisories]
+vulnerability = "deny"
+unmaintained = "deny"
+notice = "deny"
+unsound = "deny"
+
+[bans]
+multiple-versions = "allow"


### PR DESCRIPTION
I originally started lading as a side project, a little hack to write up for
technical writing purposes but found that it proved useful in my work on the
Vector project. Over time lading has got more and more useful to me and it's
more and more awkward to have it under my personal user.

Signed-off-by: Brian L. Troutwine <brian.troutwine@datadoghq.com>